### PR TITLE
Fix keycloak role listing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 gunicorn
 connexion[swagger-ui]
 flask-cors
-python-keycloak
+python-keycloak >= 0.25.0
 flask-sqlalchemy
 psycopg2-binary
 pyyaml

--- a/src/rhub/auth/keycloak.py
+++ b/src/rhub/auth/keycloak.py
@@ -102,10 +102,7 @@ class KeycloakClient:
         self.admin.group_user_remove(user_id, group_id)
 
     def group_role_list(self, group_id):
-        data = self.admin.get_group_realm_roles(group_id)
-        if not data:
-            return []
-        return data['realmMappings']
+        return self.admin.get_group_realm_roles(group_id)
 
     def group_role_add(self, role_name, group_id):
         """Add role to group. !! Role NAME, not ID !!"""


### PR DESCRIPTION
`KeycloakAdmin.get_group_realm_roles` was returning dict
`{'realmMappings': [...]}` but it was a bug fixed in 0.25.0.

https://github.com/marcospereirampj/python-keycloak/commit/92cef305787dec2485596f769692bcaa2af2b29e