### PR TITLE
Openapi spec refactoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ hvac
 requests
 attrs
 retrying
+prance

--- a/src/openapi/auth.yml
+++ b/src/openapi/auth.yml
@@ -1,0 +1,896 @@
+model:
+
+  User:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/UUID'
+          - readOnly: true
+      username:
+        type: string
+      email:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      enabled:
+        type: boolean
+    description: |
+      See [Keycloak API: UserRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
+    example:
+      access:
+        impersonate: true
+        manage: true
+        manageGroupMembership: true
+        mapRoles: true
+        view: true
+      createdTimestamp: 1614717256570
+      disableableCredentialTypes: []
+      email: testuser1@example.com
+      emailVerified: false
+      enabled: true
+      firstName: test
+      id: 743a5375-3513-4749-acb9-1cde1e159e3b
+      lastName: user1
+      notBefore: 0
+      requiredActions: []
+      totp: false
+      username: testuser1
+
+  Group:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/UUID'
+          - readOnly: true
+      name:
+        type: string
+      attributes:
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            type: string
+        description: Group attributes
+    description: |
+      See [Keycloak API: GroupRepresentation](
+      https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
+    example:
+      access:
+        manage: true
+        manageMembership: true
+        view: true
+      attributes:
+        mailing-list:
+          - admin-list@example.com
+      clientRoles: {}
+      id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
+      name: admin
+      path: /admin
+      realmRoles: []
+      subGroups: []
+
+  Role:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/UUID'
+          - readOnly: true
+      name:
+        type: string
+      attributes:
+        type: object
+        additionalProperties:
+          type: array
+          items:
+            type: string
+        description: Role attributes
+    description: |
+      See [Keycloak API: RoleRepresentation](
+      https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
+    example:
+      attributes: {}
+      id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
+      name: admin
+      clientRole: false
+      composite: false
+      composites: {}
+      containerId: admin
+      description: adminRole
+
+  Token:
+    type: object
+    example:
+      access_token: eyJhbGciOiJSUzI1...oJhA
+      expires_in: 300
+      not-before-policy: 0
+      refresh_expires_in: 1800
+      refresh_token: eyJhbGciOiJIUzI1...fc8A
+      scope: profile email
+      session_state: 82b7637e-69a2-41e1-ab0b-e3d6b6e1fb0a
+      token_type: Bearer
+
+  TokenInfo:
+    type: object
+    description: |
+      See [RFC 7662, Section 2.2](https://tools.ietf.org/html/rfc7662#section-2.2)
+      and [Keycloak API: AccessToken](https://www.keycloak.org/docs-api/11.0/rest-api/#_accesstoken)
+    example:
+      acr: '1'
+      active: true
+      allowed-origins:
+        - http://localhost:8080
+      aud: account
+      azp: rhub-app
+      client_id: rhub-app
+      email: testuser1@example.com
+      email_verified: false
+      exp: 1617791654
+      family_name: user1
+      given_name: test
+      iat: 1617791354
+      iss: http://localhost:8082/auth/realms/rhub
+      jti: 640eb3a2-a193-4998-aa5b-5f0ba5beb154
+      name: test user1
+      preferred_username: testuser1
+      realm_access:
+        roles:
+          - offline_access
+          - uma_authorization
+      resource_access:
+        account:
+          roles:
+            - manage-account
+            - manage-account-links
+            - view-profile
+      scope: profile email
+      session_state: 82b7637e-69a2-41e1-ab0b-e3d6b6e1fb0a
+      sub: 743a5375-3513-4749-acb9-1cde1e159e3b
+      typ: Bearer
+      username: testuser1
+
+parameters:
+
+  user_id:
+    name: user_id
+    in: path
+    description: ID of the user
+    required: true
+    schema:
+      $ref: 'common.yml#/model/UUID'
+  group_id:
+    name: group_id
+    in: path
+    description: ID of the user
+    required: true
+    schema:
+      $ref: 'common.yml#/model/UUID'
+  role_id:
+    name: role_id
+    in: path
+    description: ID of the auth role
+    required: true
+    schema:
+      $ref: 'common.yml#/model/UUID'
+
+endpoints:
+
+  user_list:
+    summary: Get user list
+    description: |
+      See also [Keycloak API: UserRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.user.list_users
+    responses:
+      '200':
+        description: List of User
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/User'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_create:
+    summary: Create user
+    description: |
+      Create a user in the database. Returns created user data with extra
+      fields added by auth database (UUID and other fields).
+
+      See also [Keycloak API: UserRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.user.create_user
+    requestBody:
+      description: User
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/User'
+              - required:
+                  - username
+                  - email
+          example:
+            username: alice
+            email: alice@example.com
+            firstName: Alice
+            lastName: Example
+            password: p4ssw0rd
+    responses:
+      '200':
+        description: User successfully created
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/User'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_get:
+    summary: Get user
+    description: |
+      Returns user data including extra fields added by auth database. Data
+      object contains at least properties that are in the schema but also
+      database internal data like `createdTimestamp` and others.
+
+      See also [Keycloak API: UserRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.user.get_user
+    parameters:
+      - $ref: '#/parameters/user_id'
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/User'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_update:
+    summary: Update user
+    description: |
+      Update user in the database. Returns updated user data including extra
+      fields added by auth database.
+
+      See also [Keycloak API: UserRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.user.update_user
+    parameters:
+      - $ref: '#/parameters/user_id'
+    requestBody:
+      description: User properties to update
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/User'
+          example:
+            email: alice-new@example.com
+            lastName: New
+    responses:
+      '200':
+        description: User successfully updated
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/User'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_delete:
+    summary: Delete user
+    tags: [auth]
+    operationId: rhub.api.auth.user.delete_user
+    parameters:
+      - $ref: '#/parameters/user_id'
+    responses:
+      '200':
+        description: User successfully deleted
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_list_groups:
+    summary: Get user groups
+    description: |
+      See also [Keycloak API: GroupRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.user.list_user_groups
+    parameters:
+      - $ref: '#/parameters/user_id'
+    responses:
+      '200':
+        description: List of Group
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Group'
+            example:
+              - id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
+                name: admin
+                path: /admin
+                subGroups: []
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_add_group:
+    summary: Add user to group
+    tags: [auth]
+    operationId: rhub.api.auth.user.add_user_group
+    parameters:
+      - $ref: '#/parameters/user_id'
+    requestBody:
+      description: Group ID
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/UUID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_remove_group:
+    summary: Remove user from group
+    tags: [auth]
+    operationId: rhub.api.auth.user.delete_user_group
+    parameters:
+      - $ref: '#/parameters/user_id'
+    requestBody:
+      description: Group ID
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/UUID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_list_roles:
+    summary: Get user roles
+    tags: [auth]
+    operationId: rhub.api.auth.user.list_user_roles
+    parameters:
+      - $ref: '#/parameters/user_id'
+    responses:
+      '200':
+        description: List of Role
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Role'
+            example:
+              - id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
+                name: admin
+                description: adminRole
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_add_role:
+    summary: Add user to role
+    tags: [auth]
+    operationId: rhub.api.auth.user.add_user_role
+    parameters:
+      - $ref: '#/parameters/user_id'
+    requestBody:
+      description: Role ID
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/UUID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  user_remove_role:
+    summary: Remove user from role
+    tags: [auth]
+    operationId: rhub.api.auth.user.delete_user_role
+    parameters:
+      - $ref: '#/parameters/user_id'
+    requestBody:
+      description: Role ID
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/UUID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  group_list:
+    summary: Get group list
+    description: |
+      See also [Keycloak API: GroupRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.group.list_groups
+    responses:
+      '200':
+        description: List of Group
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Group'
+            example:
+              - id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
+                name: admin
+                path: /admin
+                subGroups: []
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  group_create:
+    summary: Create group
+    description: |
+      Create a group in the database. Returns created group data with extra
+      fields added by auth database (UUID and other fields).
+
+      See also [Keycloak API: GroupRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.group.create_group
+    requestBody:
+      description: Group
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Group'
+              - required:
+                  - name
+          example:
+            name: admin
+            attributes:
+              mailing-list:
+                - admin-list@example.com
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Group'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  group_get:
+    summary: Get group
+    description: |
+      Returns group data including extra fields added by auth database. Data
+      object contains at least properties that are in the schema but also
+      database internal data like `subGroups` and others.
+
+      See also [Keycloak API: GroupRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.group.get_group
+    parameters:
+      - $ref: '#/parameters/group_id'
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Group'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  group_update:
+    summary: Update group
+    description: |
+      Update group in the database. Returns updated group data including extra
+      fields added by auth database.
+
+      See also [Keycloak API: GroupRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.group.update_group
+    parameters:
+      - $ref: '#/parameters/group_id'
+    requestBody:
+      description: Group properties to update
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Group'
+          example:
+            attributes:
+              mailing-list:
+                - admin-list@example.com
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Group'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  group_delete:
+    summary: Delete group
+    tags: [auth]
+    operationId: rhub.api.auth.group.delete_group
+    parameters:
+      - $ref: '#/parameters/group_id'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  group_list_users:
+    summary: Get users in group
+    description: |
+      See also [Keycloak API: UserRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.group.list_group_users
+    parameters:
+      - $ref: '#/parameters/group_id'
+    responses:
+      '200':
+        description: List of User
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/User'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  group_list_roles:
+    summary: Get group roles
+    tags: [auth]
+    operationId: rhub.api.auth.group.list_group_roles
+    parameters:
+      - $ref: '#/parameters/group_id'
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Role'
+            example:
+              - id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
+                name: admin
+                description: adminRole
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  group_add_role:
+    summary: Add group to role
+    tags: [auth]
+    operationId: rhub.api.auth.group.add_group_role
+    parameters:
+      - $ref: '#/parameters/group_id'
+    requestBody:
+      description: Role ID
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/UUID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  group_remove_role:
+    summary: Remove group from role
+    tags: [auth]
+    operationId: rhub.api.auth.group.delete_group_role
+    parameters:
+      - $ref: '#/parameters/group_id'
+    requestBody:
+      description: Role ID
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/UUID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  role_list:
+    summary: Get role list
+    description: |
+      See [Keycloak API: RoleRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.role.list_roles
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Role'
+            example:
+              - id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
+                name: admin
+                description: adminRole
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  role_create:
+    summary: Create role
+    description: |
+      Create a role in the database. Returns created role data with extra
+      fields added by auth database (UUID and other fields).
+
+      See [Keycloak API: RoleRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.role.create_role
+    requestBody:
+      description: Role
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Role'
+              - required:
+                  - name
+          example:
+            name: admin
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Role'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  role_get:
+    summary: Get role
+    description: |
+      Returns role data including extra fields added by auth database. Data
+      object contains at least properties that are in the schema but also
+      database internal data like `description` and others.
+
+      See [Keycloak API: RoleRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.role.get_role
+    parameters:
+      - $ref: '#/parameters/role_id'
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Role'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  role_update:
+    summary: Update role
+    description: |
+      Update role in the database. Returns updated role data including extra
+      fields added by auth database.
+
+      See [Keycloak API: RoleRepresentation](
+        https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
+    tags: [auth]
+    operationId: rhub.api.auth.role.update_role
+    parameters:
+      - $ref: '#/parameters/role_id'
+    requestBody:
+      description: Role properties to update
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Role'
+          example:
+            composite: true
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Role'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  role_delete:
+    summary: Delete role
+    tags: [auth]
+    operationId: rhub.api.auth.role.delete_role
+    parameters:
+      - $ref: '#/parameters/role_id'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  token_get_info:
+    summary: Get auth token info
+    tags: [auth]
+    operationId: rhub.api.auth.token.get_token_info
+    responses:
+      '200':
+        description: Auth token
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/TokenInfo'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  token_create:
+    summary: Login and get access token
+    description: |
+      This endpoint requires HTTP basic authentication. If credentials are
+      correct then it returns oauth2 token info - access token, refresh token
+      and some other informations about generated token.
+    tags: [auth]
+    operationId: rhub.api.auth.token.create_token
+    parameters:
+      - in: header
+        name: Authorization
+        schema:
+          type: string
+          example: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
+        required: true
+    responses:
+      '200':
+        description: Auth token
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Token'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  token_refresh:
+    summary: Refresh token
+    description: |
+      This endpoint requires HTTP bearer authentication. The bearer token in
+      'Authorization' header is not access token but refresh token. If refresh
+      was successful return new oauth2 token info. Response is the same as
+      from token create endpoint.
+    tags: [auth]
+    operationId: rhub.api.auth.token.refresh_token
+    parameters:
+      - in: header
+        name: Authorization
+        description: Bearer token is refresh token, not access token!
+        schema:
+          type: string
+          example: Bearer eyJhbGciOiJIUzI1...VLzc
+        required: true
+    responses:
+      '200':
+        description: Auth token
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Token'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  me:
+    summary: Get info about logged in user
+    tags: [auth]
+    operationId: rhub.api.auth.user.get_current_user
+    responses:
+      '200':
+        description: Success
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/User'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []

--- a/src/openapi/common.yml
+++ b/src/openapi/common.yml
@@ -4,6 +4,10 @@ model:
     type: integer
     minimum: 1
 
+  UUID:
+    type: string
+    format: uuid
+
 responses:
 
   problem:

--- a/src/openapi/common.yml
+++ b/src/openapi/common.yml
@@ -1,0 +1,30 @@
+model:
+
+  ID:
+    type: integer
+    minimum: 1
+
+responses:
+
+  problem:
+    description: Problem details ([RFC 7807](https://tools.ietf.org/html/rfc7807))
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            type:
+              type: string
+            title:
+              type: string
+            detail:
+              type: string
+            status:
+              type: integer
+          additionalProperties: true
+        example: {
+          "detail": "Invalid token",
+          "status": 401,
+          "title": "Unauthorized",
+          "type": "about:blank"
+        }

--- a/src/openapi/health.yml
+++ b/src/openapi/health.yml
@@ -1,0 +1,26 @@
+endpoints:
+
+  cowsay:
+    summary: Most important endpoint!
+    tags: [health]
+    operationId: rhub.api.health.cowsay
+    responses:
+      '200':
+        description: Success
+        content:
+          text/plain:
+            schema:
+              type: string
+
+  ping:
+    summary: Basic availablity endpoint
+    tags: [health]
+    operationId: rhub.api.health.ping
+    responses:
+      '200':
+        description: Success
+        content:
+          text/plain:
+            schema:
+              type: string
+              enum: [pong]

--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -1,0 +1,806 @@
+model:
+
+  Quota:
+    type: object
+    properties:
+      num_vcpus:
+        type: integer
+        minimum: 1
+        nullable: true
+      ram_mb:
+        type: integer
+        minimum: 1
+        nullable: true
+      num_volumes:
+        type: integer
+        minimum: 1
+        nullable: true
+      volumes_gb:
+        type: integer
+        minimum: 1
+        nullable: true
+
+  Tower:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        type: string
+        pattern: '^\w+$'
+      description:
+        type: string
+      enabled:
+        type: boolean
+      url:
+        type: string
+        format: url
+      credentials:
+        type: string
+        description: Tower credentials path (Vault mount/path)
+
+  Region:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        type: string
+        maxLength: 32
+      location:
+        description: Geographical location of region.
+        type: string
+        maxLength: 32
+        nullable: true
+      description:
+        type: string
+      banner:
+        type: string
+      enabled:
+        type: boolean
+      reservations_enabled:
+        type: boolean
+      lifespan_length:
+        type: integer
+        minimum: 1
+        nullable: true
+      quota:
+        anyOf:
+          - $ref: '#/model/Quota'
+          - nullable: true
+      owner_group:
+        type: string
+        format: uuid
+        readOnly: true
+      users_group:
+        type: string
+        format: uuid
+        nullable: true
+      tower_id:
+        $ref: 'common.yml#/model/ID'
+    example:
+      id: 1
+      name: rdu2-a
+      location: RDU
+      description: ''
+      banner: ''
+      enabled: true
+      reservation_enabled: true
+      lifespan_length: 60
+      quota:
+        num_vcpus: 40
+        ram_mb: 200000
+        num_volumes: 40
+        volumes_gb: 540
+      owner_group: 7670ac07-cb21-448d-af8a-6e3882216be3
+      users_group: null
+      tower_id: 1
+
+  Cluster:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        type: string
+        pattern: '^\w+$'
+      description:
+        type: string
+      extra_vars:
+        type: object
+      user_id:
+        $ref: 'common.yml#/model/ID'
+      region_id:
+        $ref: 'common.yml#/model/ID'
+      template_id:
+        $ref: 'common.yml#/model/ID'
+      reservation_expiration:
+        type: string
+        format: date-time
+        description: Soft-limit expiration.
+      lifespan_expiration:
+        type: string
+        format: date-time
+        readOnly: true
+        description: Hard-limit expiration.
+
+  Template:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        type: string
+        pattern: '^\w+$'
+      description:
+        type: string
+      enabled:
+        type: boolean
+
+  Bundle:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        type: string
+        pattern: '^\w+$'
+      description:
+        type: string
+      enabled:
+        type: boolean
+
+parameters:
+
+  tower_id:
+    name: tower_id
+    in: path
+    description: ID of the tower
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+  region_id:
+    name: region_id
+    in: path
+    description: ID of the region
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+  cluster_id:
+    name: cluster_id
+    in: path
+    description: ID of the cluster
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+  template_id:
+    name: template_id
+    in: path
+    description: ID of the template
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+  bundle_id:
+    name: bundle_id
+    in: path
+    description: ID of the bundle
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+
+endpoints:
+
+  tower_list:
+    summary: Get tower list
+    tags: [lab]
+    operationId: rhub.api.lab.tower.list_towers
+    responses:
+      '200':
+        description: List of Tower
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Tower'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  tower_create:
+    summary: Create tower
+    tags: [lab]
+    operationId: rhub.api.lab.tower.create_tower
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Tower'
+              - required:
+                  - name
+                  - url
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  tower_get:
+    summary: Get tower
+    tags: [lab]
+    operationId: rhub.api.lab.tower.get_tower
+    parameters:
+      - $ref: '#/parameters/tower_id'
+    responses:
+      '200':
+        description: Tower
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Tower'
+      '404':
+        description: Not found
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  tower_update:
+    summary: Update tower
+    tags: [lab]
+    operationId: rhub.api.lab.tower.update_tower
+    parameters:
+      - $ref: '#/parameters/tower_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Tower'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  tower_delete:
+    summary: Delete tower
+    tags: [lab]
+    operationId: rhub.api.lab.tower.delete_tower
+    parameters:
+      - $ref: '#/parameters/tower_id'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  region_list:
+    summary: Get region list
+    tags: [lab]
+    operationId: rhub.api.lab.region.list_regions
+    responses:
+      '200':
+        description: List of Region
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Region'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  region_create:
+    summary: Create region
+    description: |
+      See [create cluster endpoint](#/lab/rhub.api.lab.cluster.create_cluster)
+      for more info how reservation, lifespan, and other properties affects clusters.
+
+      `quota` and `lifespan` can be set to `null` to provide unlimited access
+      to the region.
+
+      `users_group` limits region to a selected group of users, if the value
+      is `null` any user can use region.
+    tags: [lab]
+    operationId: rhub.api.lab.region.create_region
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Region'
+              - required:
+                  - name
+                  - tower_id
+          example:
+            name: rdu2-a
+            location: RDU
+            enabled: true
+            reservation_enabled: true
+            lifespan_length: 60
+            quota:
+              num_vcpus: 40
+              ram_mb: 200000
+              num_volumes: 40
+              volumes_gb: 540
+            tower_id: 1
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  region_get:
+    summary: Get region
+    tags: [lab]
+    operationId: rhub.api.lab.region.get_region
+    parameters:
+      - $ref: '#/parameters/region_id'
+    responses:
+      '200':
+        description: Region
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Region'
+      '404':
+        description: Not found
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  region_update:
+    summary: Update region
+    tags: [lab]
+    operationId: rhub.api.lab.region.update_region
+    parameters:
+      - $ref: '#/parameters/region_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Region'
+          example:
+            lifespan_length: 60
+            quota:
+              num_vcpus: 40
+              ram_mb: 200000
+              num_volumes: 40
+              volumes_gb: 500
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  region_delete:
+    summary: Delete region
+    tags: [lab]
+    operationId: rhub.api.lab.region.delete_region
+    parameters:
+      - $ref: '#/parameters/region_id'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  region_list_templates:
+    summary: Get templates available on region
+    tags: [lab]
+    operationId: rhub.api.lab.region.list_region_templates
+    parameters:
+      - $ref: '#/parameters/region_id'
+    responses:
+      '200':
+        description: List of Template
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Template'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  region_add_template:
+    summary: Add template to region
+    tags: [lab]
+    operationId: rhub.api.lab.region.add_region_template
+    parameters:
+      - $ref: '#/parameters/region_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/ID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  region_remove_template:
+    summary: Remove template from region
+    tags: [lab]
+    operationId: rhub.api.lab.region.delete_region_template
+    parameters:
+      - $ref: '#/parameters/region_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/ID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  template_list:
+    summary: Get template list
+    tags: [lab]
+    operationId: rhub.api.lab.template.list_templates
+    responses:
+      '200':
+        description: List of Template
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Template'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  template_create:
+    summary: Create template
+    tags: [lab]
+    operationId: rhub.api.lab.template.create_template
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Template'
+              - required:
+                  - name
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  template_get:
+    summary: Get template
+    tags: [lab]
+    operationId: rhub.api.lab.template.get_template
+    parameters:
+      - $ref: '#/parameters/template_id'
+    responses:
+      '200':
+        description: Template
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Template'
+      '404':
+        description: Not found
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  template_update:
+    summary: Update template
+    tags: [lab]
+    operationId: rhub.api.lab.template.update_template
+    parameters:
+      - $ref: '#/parameters/template_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Template'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  template_delete:
+    summary: Delete template
+    tags: [lab]
+    operationId: rhub.api.lab.template.delete_template
+    parameters:
+      - $ref: '#/parameters/template_id'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  template_list_bundles:
+    summary: Get bundles available for template
+    tags: [lab]
+    operationId: rhub.api.lab.template.list_template_bundles
+    parameters:
+      - $ref: '#/parameters/template_id'
+    responses:
+      '200':
+        description: List of Bundle
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Bundle'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  template_add_bundle:
+    summary: Add bundle to template
+    tags: [lab]
+    operationId: rhub.api.lab.template.add_template_bundle
+    parameters:
+      - $ref: '#/parameters/template_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/ID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  template_remove_bundle:
+    summary: Remove bundle from template
+    tags: [lab]
+    operationId: rhub.api.lab.template.delete_template_bundle
+    parameters:
+      - $ref: '#/parameters/template_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                $ref: 'common.yml#/model/ID'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  bundle_list:
+    summary: Get bundle list
+    tags: [lab]
+    operationId: rhub.api.lab.bundle.list_bundles
+    responses:
+      '200':
+        description: List of Bundle
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Bundle'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  bundle_create:
+    summary: Create bundle
+    tags: [lab]
+    operationId: rhub.api.lab.bundle.create_bundle
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Bundle'
+              - required:
+                  - name
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  bundle_get:
+    summary: Get bundle
+    tags: [lab]
+    operationId: rhub.api.lab.bundle.get_bundle
+    parameters:
+      - $ref: '#/parameters/bundle_id'
+    responses:
+      '200':
+        description: Bundle
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Bundle'
+      '404':
+        description: Not found
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  bundle_update:
+    summary: Update bundle
+    tags: [lab]
+    operationId: rhub.api.lab.bundle.update_bundle
+    parameters:
+      - $ref: '#/parameters/bundle_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Bundle'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  bundle_delete:
+    summary: Delete bundle
+    tags: [lab]
+    operationId: rhub.api.lab.bundle.delete_bundle
+    parameters:
+      - $ref: '#/parameters/bundle_id'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  cluster_list:
+    summary: Get cluster list
+    tags: [lab]
+    operationId: rhub.api.lab.cluster.list_clusters
+    responses:
+      '200':
+        description: List of Cluster
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Cluster'
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  cluster_create:
+    summary: Create cluster
+    description: |
+      When the Reservation System is enabled in a region, a new cluster in
+      that region will be required to select the length of the reservation in
+      `reservation_expiration` field. Reservation sets soft-limit on cluster,
+      when reservation expires cluster will be scheduled for deletion.
+
+      When the Lifespan System is enabled in a region, `lifespan_expiration`
+      date will automatically be applied to the cluster by backend at time of
+      creation. The date is configured on region. Unlike the reservation
+      expiration, lifespan is hard-limit and this date can not be set nor
+      modified once cluster is created. When livespan expires cluster will be
+      unconditionally scheduled for deletion
+    tags: [lab]
+    operationId: rhub.api.lab.cluster.create_cluster
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Cluster'
+              - required:
+                  - name
+                  - user_id
+                  - region_id
+                  - template_id
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  cluster_get:
+    summary: Get cluster
+    tags: [lab]
+    operationId: rhub.api.lab.cluster.get_cluster
+    parameters:
+      - $ref: '#/parameters/cluster_id'
+    responses:
+      '200':
+        description: Cluster
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Cluster'
+      '404':
+        description: Not found
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  cluster_update:
+    summary: Update cluster
+    description: |
+      See [create cluster endpoint](#/lab/rhub.api.lab.cluster.create_cluster) for more info.
+    tags: [lab]
+    operationId: rhub.api.lab.cluster.update_cluster
+    parameters:
+      - $ref: '#/parameters/cluster_id'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Cluster'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+
+  cluster_delete:
+    summary: Delete cluster
+    tags: [lab]
+    operationId: rhub.api.lab.cluster.delete_cluster
+    parameters:
+      - $ref: '#/parameters/cluster_id'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'

--- a/src/openapi/openapi.yml
+++ b/src/openapi/openapi.yml
@@ -11,164 +11,12 @@ components:
     ID:
       type: integer
       minimum: 1
-    UUID:
-      type: string
-      format: uuid
     Name:
       type: string
       pattern: '^\w+$'
-
-    Quota:
-      type: object
-      properties:
-        num_vcpus:
-          type: integer
-          minimum: 1
-          nullable: true
-        ram_mb:
-          type: integer
-          minimum: 1
-          nullable: true
-        num_volumes:
-          type: integer
-          minimum: 1
-          nullable: true
-        volumes_gb:
-          type: integer
-          minimum: 1
-          nullable: true
-
-    LabTower:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          $ref: '#/components/schemas/Name'
-        description:
-          type: string
-        enabled:
-          type: boolean
-        url:
-          type: string
-          format: url
-        credentials:
-          type: string
-          description: Tower credentials path (Vault mount/path)
-    LabRegion:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          type: string
-          maxLength: 32
-        location:
-          description: Geographical location of region.
-          type: string
-          maxLength: 32
-          nullable: true
-        description:
-          type: string
-        banner:
-          type: string
-        enabled:
-          type: boolean
-        reservations_enabled:
-          type: boolean
-        lifespan_length:
-          type: integer
-          minimum: 1
-          nullable: true
-        quota:
-          anyOf:
-            - $ref: '#/components/schemas/Quota'
-            - nullable: true
-        owner_group:
-          type: string
-          format: uuid
-          readOnly: true
-        users_group:
-          type: string
-          format: uuid
-          nullable: true
-        tower_id:
-          $ref: '#/components/schemas/ID'
-      example:
-        id: 1
-        name: rdu2-a
-        location: RDU
-        description: ''
-        banner: ''
-        enabled: true
-        reservation_enabled: true
-        lifespan_length: 60
-        quota:
-          num_vcpus: 40
-          ram_mb: 200000
-          num_volumes: 40
-          volumes_gb: 540
-        owner_group: 7670ac07-cb21-448d-af8a-6e3882216be3
-        users_group: null
-        tower_id: 1
-    LabCluster:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          $ref: '#/components/schemas/Name'
-        description:
-          type: string
-        extra_vars:
-          type: object
-        user_id:
-          $ref: '#/components/schemas/ID'
-        region_id:
-          $ref: '#/components/schemas/ID'
-        template_id:
-          $ref: '#/components/schemas/ID'
-        reservation_expiration:
-          type: string
-          format: date-time
-          description: Soft-limit expiration.
-        lifespan_expiration:
-          type: string
-          format: date-time
-          readOnly: true
-          description: Hard-limit expiration.
-    LabTemplate:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          $ref: '#/components/schemas/Name'
-        description:
-          type: string
-        enabled:
-          type: boolean
-    LabBundle:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          $ref: '#/components/schemas/Name'
-        description:
-          type: string
-        enabled:
-          type: boolean
+    UUID:
+      type: string
+      format: uuid
     User:
       type: object
       properties:
@@ -533,41 +381,6 @@ components:
           x-nullable: true
 
   parameters:
-    lab_tower_id:
-      name: id
-      in: path
-      description: ID of the tower
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
-    lab_region_id:
-      name: id
-      in: path
-      description: ID of the region
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
-    lab_cluster_id:
-      name: id
-      in: path
-      description: ID of the cluster
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
-    lab_template_id:
-      name: id
-      in: path
-      description: ID of the template
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
-    lab_bundle_id:
-      name: id
-      in: path
-      description: ID of the bundle
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
     user_id:
       name: id
       in: path
@@ -628,150 +441,6 @@ components:
           schema:
             $ref: '#/components/schemas/TowerWebhookNotification'
 
-    lab_tower_post:
-      description: Tower
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/LabTower'
-              - required:
-                  - name
-                  - url
-    lab_tower_patch:
-      description: Tower properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabTower'
-    lab_region_post:
-      description: |
-        `quota` and `lifespan` can be set to `null` to provide unlimited access
-        to the region.
-
-        `users_group` limits region to a selected group of users, if the value
-        is `null` any user can use region.
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/LabRegion'
-              - required:
-                  - name
-                  - tower_id
-          example:
-            name: rdu2-a
-            location: RDU
-            enabled: true
-            reservation_enabled: true
-            lifespan_length: 60
-            quota:
-              num_vcpus: 40
-              ram_mb: 200000
-              num_volumes: 40
-              volumes_gb: 540
-            tower_id: 1
-    lab_region_patch:
-      description: |
-        Region properties to update.
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabRegion'
-          example:
-            lifespan_length: 60
-            quota:
-              num_vcpus: 40
-              ram_mb: 200000
-              num_volumes: 40
-              volumes_gb: 500
-    lab_cluster_post:
-      description: Cluster
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/LabCluster'
-              - required:
-                  - name
-                  - user_id
-                  - region_id
-                  - template_id
-    lab_cluster_patch:
-      description: Cluster properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabCluster'
-    lab_template_post:
-      description: Template
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/LabTemplate'
-              - required:
-                  - name
-    lab_template_patch:
-      description: Template properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabTemplate'
-    lab_template_id:
-      description: Template ID
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            required:
-              - id
-            properties:
-              id:
-                $ref: '#/components/schemas/ID'
-    lab_bundle_post:
-      description: Bundle
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/LabBundle'
-              - required:
-                  - name
-    lab_bundle_patch:
-      description: Bundle properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabBundle'
-    lab_bundle_id:
-      description: Bundle ID
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            required:
-              - id
-            properties:
-              id:
-                $ref: '#/components/schemas/ID'
     user_post:
       description: User
       required: true
@@ -1008,100 +677,8 @@ components:
 
 
   responses:
+    problem: {$ref: 'common.yml#/responses/problem'}  # TODO remove
 
-    problem:
-      description: Problem details ([RFC 7807](https://tools.ietf.org/html/rfc7807))
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              type:
-                type: string
-              title:
-                type: string
-              detail:
-                type: string
-              status:
-                type: integer
-            additionalProperties: true
-          example: {
-            "detail": "Invalid token",
-            "status": 401,
-            "title": "Unauthorized",
-            "type": "about:blank"
-          }
-
-    lab_tower_get:
-      description: Tower
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabTower'
-    lab_tower_list:
-      description: List of Tower
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/LabTower'
-    lab_region_get:
-      description: Region
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabRegion'
-    lab_region_list:
-      description: List of Region
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/LabRegion'
-    lab_cluster_get:
-      description: Cluster
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabCluster'
-    lab_cluster_list:
-      description: List of Cluster
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/LabCluster'
-    lab_template_get:
-      description: Template
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabTemplate'
-    lab_template_list:
-      description: List of Template
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/LabTemplate'
-    lab_bundle_get:
-      description: Bundle
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/LabBundle'
-    lab_bundle_list:
-      description: List of Bundle
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/LabBundle'
     user_get:
       description: User
       content:
@@ -1281,402 +858,79 @@ paths:
 
   /lab/tower:
     get:
-      summary: Get tower list
-      tags: [lab]
-      operationId: rhub.api.lab.tower.list_towers
-      responses:
-        200:
-          $ref: '#/components/responses/lab_tower_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/tower_list'
     post:
-      summary: Create tower
-      tags: [lab]
-      operationId: rhub.api.lab.tower.create_tower
-      requestBody:
-        $ref: '#/components/requestBodies/lab_tower_post'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-  /lab/tower/{id}:
+      $ref: 'lab.yml#/endpoints/tower_create'
+  /lab/tower/{tower_id}:
     get:
-      summary: Get tower
-      tags: [lab]
-      operationId: rhub.api.lab.tower.get_tower
-      parameters:
-        - $ref: '#/components/parameters/lab_tower_id'
-      responses:
-        200:
-          $ref: '#/components/responses/lab_tower_get'
-        404:
-          description: Not found
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/tower_get'
     patch:
-      summary: Update tower
-      tags: [lab]
-      operationId: rhub.api.lab.tower.update_tower
-      parameters:
-        - $ref: '#/components/parameters/lab_tower_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_tower_patch'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/tower_update'
     delete:
-      summary: Delete tower
-      tags: [lab]
-      operationId: rhub.api.lab.tower.delete_tower
-      parameters:
-        - $ref: '#/components/parameters/lab_tower_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/tower_delete'
   /lab/region:
     get:
-      summary: Get region list
-      tags: [lab]
-      operationId: rhub.api.lab.region.list_regions
-      responses:
-        200:
-          $ref: '#/components/responses/lab_region_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'lab.yml#/endpoints/region_list'
     post:
-      summary: Create region
-      description: |
-        See [create cluster endpoint](#/lab/rhub.api.lab.cluster.create_cluster)
-        for more info how reservation, lifespan, and other properties affects clusters.
-      tags: [lab]
-      operationId: rhub.api.lab.region.create_region
-      requestBody:
-        $ref: '#/components/requestBodies/lab_region_post'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
-  /lab/region/{id}:
+      $ref: 'lab.yml#/endpoints/region_create'
+  /lab/region/{region_id}:
     get:
-      summary: Get region
-      tags: [lab]
-      operationId: rhub.api.lab.region.get_region
-      parameters:
-        - $ref: '#/components/parameters/lab_region_id'
-      responses:
-        200:
-          $ref: '#/components/responses/lab_region_get'
-        404:
-          description: Not found
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'lab.yml#/endpoints/region_get'
     patch:
-      summary: Update region
-      tags: [lab]
-      operationId: rhub.api.lab.region.update_region
-      parameters:
-        - $ref: '#/components/parameters/lab_region_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_region_patch'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'lab.yml#/endpoints/region_update'
     delete:
-      summary: Delete region
-      tags: [lab]
-      operationId: rhub.api.lab.region.delete_region
-      parameters:
-        - $ref: '#/components/parameters/lab_region_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
-  /lab/region/{id}/templates:
+      $ref: 'lab.yml#/endpoints/region_delete'
+  /lab/region/{region_id}/templates:
     get:
-      summary: Get templates available on region
-      tags: [lab]
-      operationId: rhub.api.lab.region.list_region_templates
-      parameters:
-        - $ref: '#/components/parameters/lab_region_id'
-      responses:
-        200:
-          $ref: '#/components/responses/lab_template_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/region_list_templates'
     post:
-      summary: Add template to region
-      tags: [lab]
-      operationId: rhub.api.lab.region.add_region_template
-      parameters:
-        - $ref: '#/components/parameters/lab_region_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_template_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/region_add_template'
     delete:
-      summary: Remove template from region
-      tags: [lab]
-      operationId: rhub.api.lab.region.delete_region_template
-      parameters:
-        - $ref: '#/components/parameters/lab_region_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_template_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/region_remove_template'
   /lab/template:
     get:
-      summary: Get template list
-      tags: [lab]
-      operationId: rhub.api.lab.template.list_templates
-      responses:
-        200:
-          $ref: '#/components/responses/lab_template_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/template_list'
     post:
-      summary: Create template
-      tags: [lab]
-      operationId: rhub.api.lab.template.create_template
-      requestBody:
-        $ref: '#/components/requestBodies/lab_template_post'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-  /lab/template/{id}:
+      $ref: 'lab.yml#/endpoints/template_create'
+  /lab/template/{template_id}:
     get:
-      summary: Get template
-      tags: [lab]
-      operationId: rhub.api.lab.template.get_template
-      parameters:
-        - $ref: '#/components/parameters/lab_template_id'
-      responses:
-        200:
-          $ref: '#/components/responses/lab_template_get'
-        404:
-          description: Not found
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/template_get'
     patch:
-      summary: Update template
-      tags: [lab]
-      operationId: rhub.api.lab.template.update_template
-      parameters:
-        - $ref: '#/components/parameters/lab_template_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_template_patch'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/template_update'
     delete:
-      summary: Delete template
-      tags: [lab]
-      operationId: rhub.api.lab.template.delete_template
-      parameters:
-        - $ref: '#/components/parameters/lab_template_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-  /lab/template/{id}/bundles:
+      $ref: 'lab.yml#/endpoints/template_delete'
+  /lab/template/{template_id}/bundles:
     get:
-      summary: Get bundles available for template
-      tags: [lab]
-      operationId: rhub.api.lab.template.list_template_bundles
-      parameters:
-        - $ref: '#/components/parameters/lab_template_id'
-      responses:
-        200:
-          $ref: '#/components/responses/lab_bundle_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/template_list_bundles'
     post:
-      summary: Add bundle to template
-      tags: [lab]
-      operationId: rhub.api.lab.template.add_template_bundle
-      parameters:
-        - $ref: '#/components/parameters/lab_template_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_bundle_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/template_add_bundle'
     delete:
-      summary: Remove bundle from template
-      tags: [lab]
-      operationId: rhub.api.lab.template.delete_template_bundle
-      parameters:
-        - $ref: '#/components/parameters/lab_template_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_bundle_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/template_remove_bundle'
   /lab/bundle:
     get:
-      summary: Get bundle list
-      tags: [lab]
-      operationId: rhub.api.lab.bundle.list_bundles
-      responses:
-        200:
-          $ref: '#/components/responses/lab_bundle_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/bundle_list'
     post:
-      summary: Create bundle
-      tags: [lab]
-      operationId: rhub.api.lab.bundle.create_bundle
-      requestBody:
-        $ref: '#/components/requestBodies/lab_bundle_post'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-  /lab/bundle/{id}:
+      $ref: 'lab.yml#/endpoints/bundle_create'
+  /lab/bundle/{bundle_id}:
     get:
-      summary: Get bundle
-      tags: [lab]
-      operationId: rhub.api.lab.bundle.get_bundle
-      parameters:
-        - $ref: '#/components/parameters/lab_bundle_id'
-      responses:
-        200:
-          $ref: '#/components/responses/lab_bundle_get'
-        404:
-          description: Not found
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/bundle_get'
     patch:
-      summary: Update bundle
-      tags: [lab]
-      operationId: rhub.api.lab.bundle.update_bundle
-      parameters:
-        - $ref: '#/components/parameters/lab_bundle_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_bundle_patch'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/bundle_update'
     delete:
-      summary: Delete bundle
-      tags: [lab]
-      operationId: rhub.api.lab.bundle.delete_bundle
-      parameters:
-        - $ref: '#/components/parameters/lab_bundle_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/bundle_delete'
   /lab/cluster:
     get:
-      summary: Get cluster list
-      tags: [lab]
-      operationId: rhub.api.lab.cluster.list_clusters
-      responses:
-        200:
-          $ref: '#/components/responses/lab_cluster_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/cluster_list'
     post:
-      summary: Create cluster
-      description: |
-        When the Reservation System is enabled in a region, a new cluster in
-        that region will be required to select the length of the reservation in
-        `reservation_expiration` field. Reservation sets soft-limit on cluster,
-        when reservation expires cluster will be scheduled for deletion.
-
-        When the Lifespan System is enabled in a region, `lifespan_expiration`
-        date will automatically be applied to the cluster by backend at time of
-        creation. The date is configured on region. Unlike the reservation
-        expiration, lifespan is hard-limit and this date can not be set nor
-        modified once cluster is created. When livespan expires cluster will be
-        unconditionally scheduled for deletion
-      tags: [lab]
-      operationId: rhub.api.lab.cluster.create_cluster
-      requestBody:
-        $ref: '#/components/requestBodies/lab_cluster_post'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-  /lab/cluster/{id}:
+      $ref: 'lab.yml#/endpoints/cluster_create'
+  /lab/cluster/{cluster_id}:
     get:
-      summary: Get cluster
-      tags: [lab]
-      operationId: rhub.api.lab.cluster.get_cluster
-      parameters:
-        - $ref: '#/components/parameters/lab_cluster_id'
-      responses:
-        200:
-          $ref: '#/components/responses/lab_cluster_get'
-        404:
-          description: Not found
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/cluster_get'
     patch:
-      summary: Update cluster
-      description: |
-        See [create cluster endpoint](#/lab/rhub.api.lab.cluster.create_cluster) for more info.
-      tags: [lab]
-      operationId: rhub.api.lab.cluster.update_cluster
-      parameters:
-        - $ref: '#/components/parameters/lab_cluster_id'
-      requestBody:
-        $ref: '#/components/requestBodies/lab_cluster_patch'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/cluster_update'
     delete:
-      summary: Delete cluster
-      tags: [lab]
-      operationId: rhub.api.lab.cluster.delete_cluster
-      parameters:
-        - $ref: '#/components/parameters/lab_cluster_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'lab.yml#/endpoints/cluster_delete'
+
   /auth/user:
     get:
       summary: Get user list

--- a/src/openapi/openapi.yml
+++ b/src/openapi/openapi.yml
@@ -157,29 +157,10 @@ tags:
 paths:
   /cowsay:
     get:
-      summary: Most important endpoint!
-      tags: [health]
-      operationId: rhub.api.health.cowsay
-      responses:
-        200:
-          description: Success
-          content:
-            text/plain:
-              schema:
-                type: string
+      $ref: 'health.yml#/endpoints/cowsay'
   /ping:
     get:
-      summary: Basic availablity endpoint
-      tags: [health]
-      operationId: rhub.api.health.ping
-      responses:
-        200:
-          description: Success
-          content:
-            text/plain:
-              schema:
-                type: string
-                enum: [pong]
+      $ref: 'health.yml#/endpoints/ping'
 
   /lab/tower:
     get:

--- a/src/openapi/openapi.yml
+++ b/src/openapi/openapi.yml
@@ -11,89 +11,6 @@ components:
     ID:
       type: integer
       minimum: 1
-    UUID:
-      type: string
-      format: uuid
-    Name:
-      type: string
-      pattern: '^\w+$'
-    TowerServer:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          $ref: '#/components/schemas/Name'
-        description:
-          type: string
-        enabled:
-          type: boolean
-        url:
-          type: string
-          format: url
-        credentials:
-          type: string
-          description: Tower credentials path (Vault mount/path)
-    TowerTemplate:
-      type: object
-      properties:
-        id:
-          description: Internal ID
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          type: string
-        description:
-          type: string
-        server_id:
-          description: Reference to TowerServer (TowerServer.id)
-          $ref: '#/components/schemas/ID'
-        tower_template_id:
-          description: ID of template in remote Tower
-          $ref: '#/components/schemas/ID'
-        tower_template_is_workflow:
-          description: Is template workflow?
-          type: boolean
-    TowerJob:
-      type: object
-      properties:
-        id:
-          description: Internal ID
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        template_id:
-          description: Reference to TowerTemplate (TowerTemplate.id)
-          $ref: '#/components/schemas/ID'
-        tower_job_id:
-          description: ID of job in remote Tower
-          $ref: '#/components/schemas/ID'
-        launched_by:
-          description: UUID of user who launched job
-          $ref: '#/components/schemas/UUID'
-        status:
-          description: Job status
-          type: string
-        created_at:
-          type: string
-          format: date-time
-        started:
-          type: boolean
-        started_at:
-          type: string
-          format: date-time
-          x-nullable: true
-        finished:
-          type: boolean
-        finished_at:
-          type: string
-          format: date-time
-          x-nullable: true
-        failed:
-          type: boolean
     Policy:
       type: object
       properties:
@@ -144,115 +61,8 @@ components:
         department:
           description: Department Name
           type: string
-    TowerWebhookNotification:
-      type: object
-      properties:
-        id:
-          description: jobId
-          type: integer
-        name:
-          description: jobName
-          type: string
-        url:
-          description: URL to Job on Tower
-          type: string
-        created_by:
-          $ref: '#/components/schemas/UUID'
-        started:
-          description: Date/Time job started
-          type: string
-          format: date-time
-          x-nullable: true
-        finished:
-          description: Date/Time job finished
-          type: string
-          format: date-time
-          x-nullable: true
-        status:
-          description: Job status
-          type: string
-        traceback:
-          description: Traceback if failed
-          type: string
-          x-nullable: true
-        inventory:
-          description: Inventory used by Job
-          type: string
-          x-nullable: true
-        project:
-          description: Project job belongs to
-          type: string
-          x-nullable: true
-        playbook:
-          description: Playbook executed in Job
-          type: string
-          x-nullable: true
-        credential:
-          description: Credential used by Job
-          type: string
-          x-nullable: true
-        limit:
-          description: Job limit
-          type: string
-          x-nullable: true
-        extra_vars:
-          type: string
-          description: Extra variables for playbook encoded as a dictionary within a string
-          x-nullable: true
-        hosts:
-          type: object
-          additionalProperties:
-            type: object
-            properties:
-              localhost:
-                type: object
-                properties:
-                  failed:
-                    type: boolean
-                  changed:
-                    type: integer
-                  dark:
-                    type: integer
-                  failures:
-                    type: integer
-                  ok:
-                    type: integer
-                  processed:
-                    type: integer
-                  skipped:
-                    type: integer
-                  rescued:
-                    type: integer
-                  ignored:
-                    type: integer
-          x-nullable: true
-        body:
-          type: string
-          description: Enumerates all the nodes in the workflow job with a description of the job associated with each
-          x-nullable: true
 
   parameters:
-    tower_server_id:
-      name: server_id
-      in: path
-      description: ID of the Tower server
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
-    tower_template_id:
-      name: template_id
-      in: path
-      description: ID of the Tower template
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
-    tower_job_id:
-      name: job_id
-      in: path
-      description: ID of the Tower job
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
     policy_id:
       name: id
       in: path
@@ -263,107 +73,6 @@ components:
 
   requestBodies:
 
-    tower_webhook_notification_post:
-      description: Webhook notification from Tower
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/TowerWebhookNotification'
-
-    tower_server_post:
-      description: Tower Server
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/TowerServer'
-              - required:
-                  - name
-                  - url
-                  - credentials
-          example:
-            name: default
-            url: https://tower.example.com
-            credentials: kv/tower/prod/rhub
-    tower_server_patch:
-      description: Tower Server properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/TowerServer'
-          example:
-            description: Default Tower server
-    tower_server_id:
-      description: Tower Server ID
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            required:
-              - id
-            properties:
-              id:
-                $ref: '#/components/schemas/ID'
-    tower_template_post:
-      description: Tower Template
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/TowerTemplate'
-              - required:
-                  - name
-                  - server_id
-                  - tower_template_id
-          example:
-            name: Create OpenStack project
-            tower_id: 1
-            tower_template_id: 123
-    tower_template_patch:
-      description: Tower Template properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/TowerServer'
-          example:
-            description: Template to create a new project in OpenStack
-    tower_template_id:
-      description: Tower Template ID
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            required:
-              - id
-            properties:
-              id:
-                $ref: '#/components/schemas/ID'
-    tower_template_launch:
-      description: Tower Template launch parameters
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              extra_vars:
-                type: object
-                description: Extra variable to pass to the template
-            required:
-              - extra_vars
-          example:
-            extra_vars:
-              project_name: example-project
-              project_owner: example-user
     policy_post:
       description: Policy
       required: true
@@ -408,54 +117,6 @@ components:
   responses:
     problem: {$ref: 'common.yml#/responses/problem'}  # TODO remove
 
-    tower_server_get:
-      description: Tower Server
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/TowerServer'
-    tower_server_list:
-      description: List of Tower Server
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/TowerServer'
-    tower_template_get:
-      description: Tower Template
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/TowerTemplate'
-              - type: object
-                properties:
-                  tower_survey:
-                    type: object
-                    description: Survey spec from Tower API
-    tower_template_list:
-      description: List of Tower Template
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/TowerTemplate'
-    tower_job_get:
-      description: Tower Job
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/TowerJob'
-    tower_job_list:
-      description: List of Tower Jobs
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/TowerJob'
     policies_list:
       description: List of Policies
       content:
@@ -470,7 +131,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Policy'
-
 
   securitySchemes:
     basic:
@@ -671,239 +331,49 @@ paths:
 
   /tower/server:
     get:
-      summary: Get list of Tower servers
-      operationId: rhub.api.tower.list_servers
-      tags: [tower]
-      responses:
-        200:
-          $ref: '#/components/responses/tower_server_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/server_list'
     post:
-      summary: Create Tower server
-      operationId: rhub.api.tower.create_server
-      tags: [tower]
-      requestBody:
-        $ref: '#/components/requestBodies/tower_server_post'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_server_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/server_create'
   /tower/server/{server_id}:
     get:
-      summary: Get Tower server
-      operationId: rhub.api.tower.get_server
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_server_id'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_server_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/server_get'
     patch:
-      summary: Change Tower server
-      operationId: rhub.api.tower.update_server
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_server_id'
-      requestBody:
-        $ref: '#/components/requestBodies/tower_server_patch'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_server_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/server_update'
     delete:
-      operationId: rhub.api.tower.delete_server
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_server_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/server_delete'
   /tower/template:
     get:
-      summary: Get list of Tower templates
-      operationId: rhub.api.tower.list_templates
-      tags: [tower]
-      responses:
-        200:
-          $ref: '#/components/responses/tower_template_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/template_list'
     post:
-      summary: Create Tower template
-      operationId: rhub.api.tower.create_template
-      tags: [tower]
-      requestBody:
-        $ref: '#/components/requestBodies/tower_template_post'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_template_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/template_create'
   /tower/template/{template_id}:
     get:
-      summary: Get Tower template
-      operationId: rhub.api.tower.get_template
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_template_id'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_template_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/template_get'
     patch:
-      summary: Change Tower template
-      operationId: rhub.api.tower.update_template
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_template_id'
-      requestBody:
-        $ref: '#/components/requestBodies/tower_template_patch'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_template_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/template_update'
     delete:
-      summary: Delete Tower template
-      operationId: rhub.api.tower.delete_template
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_template_id'
-      responses:
-        200:
-          description: success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/template_delete'
   /tower/template/{template_id}/launch:
     post:
-      summary: Launch Tower template
-      operationId: rhub.api.tower.launch_template
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_template_id'
-      requestBody:
-        $ref: '#/components/requestBodies/tower_template_launch'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_job_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/template_launch'
   /tower/template/{template_id}/jobs:
     get:
-      summary: List Tower template jobs
-      operationId: rhub.api.tower.list_template_jobs
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_template_id'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_job_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/template_list_jobs'
   /tower/job:
     get:
-      summary: List Tower jobs
-      operationId: rhub.api.tower.list_jobs
-      tags: [tower]
-      responses:
-        200:
-          $ref: '#/components/responses/tower_job_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/job_list'
   /tower/job/{job_id}:
     get:
-      summary: Get Tower job
-      operationId: rhub.api.tower.get_job
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_job_id'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_job_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/job_get'
   /tower/job/{job_id}/relaunch:
     post:
-      summary: Re-launch Tower job
-      operationId: rhub.api.tower.relaunch_job
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_job_id'
-      responses:
-        200:
-          $ref: '#/components/responses/tower_job_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/job_relaunch'
   /tower/job/{job_id}/stdout:
     get:
-      summary: Get stdout of Tower job
-      operationId: rhub.api.tower.get_job_stdout
-      tags: [tower]
-      parameters:
-        - $ref: '#/components/parameters/tower_job_id'
-      responses:
-        200:
-          description: Ansible output
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'tower.yml#/endpoints/job_stdout'
   /tower/webhook_notification:
     post:
-      summary: Incoming webhook notification from Tower
-      tags: [tower]
-      operationId: rhub.api.tower.webhook_notification
-      requestBody:
-        $ref: '#/components/requestBodies/tower_webhook_notification_post'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - tower_webhook_notification_auth: []
+      $ref: 'tower.yml#/endpoints/webhook_notification'
   /policies:
     get:
       summary: Get policy list

--- a/src/openapi/openapi.yml
+++ b/src/openapi/openapi.yml
@@ -11,161 +11,12 @@ components:
     ID:
       type: integer
       minimum: 1
-    Name:
-      type: string
-      pattern: '^\w+$'
     UUID:
       type: string
       format: uuid
-    User:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/UUID'
-            - readOnly: true
-        username:
-          type: string
-        email:
-          type: string
-        firstName:
-          type: string
-        lastName:
-          type: string
-        enabled:
-          type: boolean
-      description: |
-        See [Keycloak API: UserRepresentation](
-          https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
-      example:
-        access:
-          impersonate: true
-          manage: true
-          manageGroupMembership: true
-          mapRoles: true
-          view: true
-        createdTimestamp: 1614717256570
-        disableableCredentialTypes: []
-        email: testuser1@example.com
-        emailVerified: false
-        enabled: true
-        firstName: test
-        id: 743a5375-3513-4749-acb9-1cde1e159e3b
-        lastName: user1
-        notBefore: 0
-        requiredActions: []
-        totp: false
-        username: testuser1
-    Group:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/UUID'
-            - readOnly: true
-        name:
-          type: string
-        attributes:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
-          description: Group attributes
-      description: |
-        See [Keycloak API: GroupRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
-      example:
-        access:
-          manage: true
-          manageMembership: true
-          view: true
-        attributes:
-          mailing-list:
-            - admin-list@example.com
-        clientRoles: {}
-        id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
-        name: admin
-        path: /admin
-        realmRoles: []
-        subGroups: []
-    Role:
-      type: object
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/UUID'
-            - readOnly: true
-        name:
-          type: string
-        attributes:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
-          description: Role attributes
-      description: |
-        See [Keycloak API: RoleRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
-      example:
-        attributes: {}
-        id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
-        name: admin
-        clientRole: false
-        composite: false
-        composites: {}
-        containerId: admin
-        description: adminRole
-    AuthToken:
-      type: object
-      example:
-        access_token: eyJhbGciOiJSUzI1...oJhA
-        expires_in: 300
-        not-before-policy: 0
-        refresh_expires_in: 1800
-        refresh_token: eyJhbGciOiJIUzI1...fc8A
-        scope: profile email
-        session_state: 82b7637e-69a2-41e1-ab0b-e3d6b6e1fb0a
-        token_type: Bearer
-    AuthTokenInfo:
-      type: object
-      description: |
-        See [RFC 7662, Section 2.2](https://tools.ietf.org/html/rfc7662#section-2.2)
-        and [Keycloak API: AccessToken](https://www.keycloak.org/docs-api/11.0/rest-api/#_accesstoken)
-      example:
-        acr: '1'
-        active: true
-        allowed-origins:
-          - http://localhost:8080
-        aud: account
-        azp: rhub-app
-        client_id: rhub-app
-        email: testuser1@example.com
-        email_verified: false
-        exp: 1617791654
-        family_name: user1
-        given_name: test
-        iat: 1617791354
-        iss: http://localhost:8082/auth/realms/rhub
-        jti: 640eb3a2-a193-4998-aa5b-5f0ba5beb154
-        name: test user1
-        preferred_username: testuser1
-        realm_access:
-          roles:
-            - offline_access
-            - uma_authorization
-        resource_access:
-          account:
-            roles:
-              - manage-account
-              - manage-account-links
-              - view-profile
-        scope: profile email
-        session_state: 82b7637e-69a2-41e1-ab0b-e3d6b6e1fb0a
-        sub: 743a5375-3513-4749-acb9-1cde1e159e3b
-        typ: Bearer
-        username: testuser1
+    Name:
+      type: string
+      pattern: '^\w+$'
     TowerServer:
       type: object
       properties:
@@ -381,27 +232,6 @@ components:
           x-nullable: true
 
   parameters:
-    user_id:
-      name: id
-      in: path
-      description: ID of the user
-      required: true
-      schema:
-        $ref: '#/components/schemas/UUID'
-    group_id:
-      name: id
-      in: path
-      description: ID of the user
-      required: true
-      schema:
-        $ref: '#/components/schemas/UUID'
-    role_id:
-      name: id
-      in: path
-      description: ID of the auth role
-      required: true
-      schema:
-        $ref: '#/components/schemas/UUID'
     tower_server_id:
       name: server_id
       in: path
@@ -441,107 +271,6 @@ components:
           schema:
             $ref: '#/components/schemas/TowerWebhookNotification'
 
-    user_post:
-      description: User
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/User'
-              - required:
-                  - username
-                  - email
-          example:
-            username: alice
-            email: alice@example.com
-            firstName: Alice
-            lastName: Example
-            password: p4ssw0rd
-    user_patch:
-      description: User properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/User'
-          example:
-            email: alice-new@example.com
-            lastName: New
-    group_post:
-      description: Group
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/Group'
-              - required:
-                  - name
-          example:
-            name: admin
-            attributes:
-              mailing-list:
-                - admin-list@example.com
-    group_patch:
-      description: Group properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Group'
-          example:
-            attributes:
-              mailing-list:
-                - admin-list@example.com
-    group_id:
-      description: Group ID
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            required:
-              - id
-            properties:
-              id:
-                $ref: '#/components/schemas/UUID'
-    role_post:
-      description: Role
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/Role'
-              - required:
-                  - name
-          example:
-            name: admin
-    role_patch:
-      description: Role properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Role'
-          example:
-            composite: true
-    role_id:
-      description: Role ID
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            required:
-              - id
-            properties:
-              id:
-                $ref: '#/components/schemas/UUID'
     tower_server_post:
       description: Tower Server
       required: true
@@ -679,70 +408,6 @@ components:
   responses:
     problem: {$ref: 'common.yml#/responses/problem'}  # TODO remove
 
-    user_get:
-      description: User
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/User'
-    user_list:
-      description: List of User
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/User'
-    group_get:
-      description: Group
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Group'
-    group_list:
-      description: List of Group
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/Group'
-          example:
-            - id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
-              name: admin
-              path: /admin
-              subGroups: []
-    role_get:
-      description: Role
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Role'
-    role_list:
-      description: List of Role
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/Role'
-          example:
-            - id: fa831aa3-7a5a-4667-9c3f-bf20465058f6
-              name: admin
-              description: adminRole
-
-    auth_token:
-      description: Auth token
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/AuthToken'
-    auth_token_info:
-      description: Auth token
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/AuthTokenInfo'
     tower_server_get:
       description: Tower Server
       content:
@@ -933,475 +598,77 @@ paths:
 
   /auth/user:
     get:
-      summary: Get user list
-      description: |
-        See also [Keycloak API: UserRepresentation](
-          https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.user.list_users
-      responses:
-        200:
-          $ref: '#/components/responses/user_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/user_list'
     post:
-      summary: Create user
-      description: |
-        Create a user in the database. Returns created user data with extra
-        fields added by auth database (UUID and other fields).
-
-        See also [Keycloak API: UserRepresentation](
-          https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.user.create_user
-      requestBody:
-        $ref: '#/components/requestBodies/user_post'
-      responses:
-        200:
-          description: User successfully created
-          $ref: '#/components/responses/user_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
-  /auth/user/{id}:
+      $ref: 'auth.yml#/endpoints/user_create'
+  /auth/user/{user_id}:
     get:
-      summary: Get user
-      description: |
-        Returns user data including extra fields added by auth database. Data
-        object contains at least properties that are in the schema but also
-        database internal data like `createdTimestamp` and others.
-
-        See also [Keycloak API: UserRepresentation](
-          https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.user.get_user
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      responses:
-        200:
-          $ref: '#/components/responses/user_get'
-        404:
-          description: User not found
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/user_get'
     patch:
-      summary: Update user
-      description: |
-        Update user in the database. Returns updated user data including extra
-        fields added by auth database.
-
-        See also [Keycloak API: UserRepresentation](
-          https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.user.update_user
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      requestBody:
-        $ref: '#/components/requestBodies/user_patch'
-      responses:
-        200:
-          description: User successfully updated
-          $ref: '#/components/responses/user_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/user_update'
     delete:
-      summary: Delete user
-      tags: [auth]
-      operationId: rhub.api.auth.user.delete_user
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      responses:
-        200:
-          description: User successfully deleted
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
-  /auth/user/{id}/groups:
+      $ref: 'auth.yml#/endpoints/user_delete'
+  /auth/user/{user_id}/groups:
     get:
-      summary: Get user groups
-      description: |
-        See also [Keycloak API: GroupRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.user.list_user_groups
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      responses:
-        200:
-          $ref: '#/components/responses/group_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/user_list_groups'
     post:
-      summary: Add user to group
-      tags: [auth]
-      operationId: rhub.api.auth.user.add_user_group
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      requestBody:
-        $ref: '#/components/requestBodies/group_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/user_add_group'
     delete:
-      summary: Remove user from group
-      tags: [auth]
-      operationId: rhub.api.auth.user.delete_user_group
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      requestBody:
-        $ref: '#/components/requestBodies/group_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
-  /auth/user/{id}/roles:
+      $ref: 'auth.yml#/endpoints/user_remove_group'
+  /auth/user/{user_id}/roles:
     get:
-      summary: Get user roles
-      tags: [auth]
-      operationId: rhub.api.auth.user.list_user_roles
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      responses:
-        200:
-          $ref: '#/components/responses/role_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/user_list_roles'
     post:
-      summary: Add user to role
-      tags: [auth]
-      operationId: rhub.api.auth.user.add_user_role
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      requestBody:
-        $ref: '#/components/requestBodies/role_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/user_add_role'
     delete:
-      summary: Remove user from role
-      tags: [auth]
-      operationId: rhub.api.auth.user.delete_user_role
-      parameters:
-        - $ref: '#/components/parameters/user_id'
-      requestBody:
-        $ref: '#/components/requestBodies/role_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/user_remove_role'
   /auth/group:
     get:
-      summary: Get group list
-      description: |
-        See also [Keycloak API: GroupRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.group.list_groups
-      responses:
-        200:
-          $ref: '#/components/responses/group_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/group_list'
     post:
-      summary: Create group
-      description: |
-        Create a group in the database. Returns created group data with extra
-        fields added by auth database (UUID and other fields).
-
-        See also [Keycloak API: GroupRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.group.create_group
-      requestBody:
-        $ref: '#/components/requestBodies/group_post'
-      responses:
-        200:
-          description: Success
-          $ref: '#/components/responses/group_get'
-        default:
-          $ref: '#/components/responses/problem'
-  /auth/group/{id}:
+      $ref: 'auth.yml#/endpoints/group_create'
+  /auth/group/{group_id}:
     get:
-      summary: Get group
-      description: |
-        Returns group data including extra fields added by auth database. Data
-        object contains at least properties that are in the schema but also
-        database internal data like `subGroups` and others.
-
-        See also [Keycloak API: GroupRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.group.get_group
-      parameters:
-        - $ref: '#/components/parameters/group_id'
-      responses:
-        200:
-          $ref: '#/components/responses/group_get'
-        404:
-          description: Not found
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/group_get'
     patch:
-      summary: Update group
-      description: |
-        Update group in the database. Returns updated group data including extra
-        fields added by auth database.
-
-        See also [Keycloak API: GroupRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_grouprepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.group.update_group
-      parameters:
-        - $ref: '#/components/parameters/group_id'
-      requestBody:
-        $ref: '#/components/requestBodies/group_patch'
-      responses:
-        200:
-          description: Success
-          $ref: '#/components/responses/group_get'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/group_update'
     delete:
-      summary: Delete group
-      tags: [auth]
-      operationId: rhub.api.auth.group.delete_group
-      parameters:
-        - $ref: '#/components/parameters/group_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
-  /auth/group/{id}/users:
+      $ref: 'auth.yml#/endpoints/group_delete'
+  /auth/group/{group_id}/users:
     get:
-      summary: Get users in group
-      description: |
-        See also [Keycloak API: UserRepresentation](
-          https://www.keycloak.org/docs-api/11.0/rest-api/#_userrepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.group.list_group_users
-      parameters:
-        - $ref: '#/components/parameters/group_id'
-      responses:
-        200:
-          $ref: '#/components/responses/user_list'
-        default:
-          $ref: '#/components/responses/problem'
-  /auth/group/{id}/roles:
+      $ref: 'auth.yml#/endpoints/group_list_users'
+  /auth/group/{group_id}/roles:
     get:
-      summary: Get group roles
-      tags: [auth]
-      operationId: rhub.api.auth.group.list_group_roles
-      parameters:
-        - $ref: '#/components/parameters/group_id'
-      responses:
-        200:
-          $ref: '#/components/responses/role_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/group_list_roles'
     post:
-      summary: Add group to role
-      tags: [auth]
-      operationId: rhub.api.auth.group.add_group_role
-      parameters:
-        - $ref: '#/components/parameters/group_id'
-      requestBody:
-        $ref: '#/components/requestBodies/role_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/group_add_role'
     delete:
-      summary: Remove group from role
-      tags: [auth]
-      operationId: rhub.api.auth.group.delete_group_role
-      parameters:
-        - $ref: '#/components/parameters/group_id'
-      requestBody:
-        $ref: '#/components/requestBodies/role_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/group_remove_role'
   /auth/role:
     get:
-      summary: Get role list
-      description: |
-        See [Keycloak API: RoleRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.role.list_roles
-      responses:
-        200:
-          $ref: '#/components/responses/role_list'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/role_list'
     post:
-      summary: Create role
-      description: |
-        Create a role in the database. Returns created role data with extra
-        fields added by auth database (UUID and other fields).
-
-        See [Keycloak API: RoleRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.role.create_role
-      requestBody:
-        $ref: '#/components/requestBodies/role_post'
-      responses:
-        200:
-          description: Success
-          $ref: '#/components/responses/role_get'
-        default:
-          $ref: '#/components/responses/problem'
-  /auth/role/{id}:
+      $ref: 'auth.yml#/endpoints/role_create'
+  /auth/role/{role_id}:
     get:
-      summary: Get role
-      description: |
-        Returns role data including extra fields added by auth database. Data
-        object contains at least properties that are in the schema but also
-        database internal data like `description` and others.
-
-        See [Keycloak API: RoleRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.role.get_role
-      parameters:
-        - $ref: '#/components/parameters/role_id'
-      responses:
-        200:
-          $ref: '#/components/responses/role_get'
-        404:
-          description: Not found
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/role_get'
     patch:
-      summary: Update role
-      description: |
-        Update role in the database. Returns updated role data including extra
-        fields added by auth database.
-
-        See [Keycloak API: RoleRepresentation](
-         https://www.keycloak.org/docs-api/11.0/rest-api/#_rolerepresentation)
-      tags: [auth]
-      operationId: rhub.api.auth.role.update_role
-      parameters:
-        - $ref: '#/components/parameters/role_id'
-      requestBody:
-        $ref: '#/components/requestBodies/role_patch'
-      responses:
-        200:
-          description: Success
-          $ref: '#/components/responses/role_get'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/role_update'
     delete:
-      summary: Delete role
-      tags: [auth]
-      operationId: rhub.api.auth.role.delete_role
-      parameters:
-        - $ref: '#/components/parameters/role_id'
-      responses:
-        200:
-          description: Success
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/role_delete'
   /auth/token:
     get:
-      summary: Get auth token info
-      tags: [auth]
-      operationId: rhub.api.auth.token.get_token_info
-      responses:
-        200:
-          $ref: '#/components/responses/auth_token_info'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/token_get_info'
   /auth/token/create:
     post:
-      summary: Login and get access token
-      description: |
-        This endpoint requires HTTP basic authentication. If credentials are
-        correct then it returns oauth2 token info - access token, refresh token
-        and some other informations about generated token.
-      tags: [auth]
-      operationId: rhub.api.auth.token.create_token
-      parameters:
-        - in: header
-          name: Authorization
-          schema:
-            type: string
-            example: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
-          required: true
-      responses:
-        200:
-          $ref: '#/components/responses/auth_token'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/token_create'
   /auth/token/refresh:
     post:
-      summary: Refresh token
-      description: |
-        This endpoint requires HTTP bearer authentication. The bearer token in
-        'Authorization' header is not access token but refresh token. If refresh
-        was successful return new oauth2 token info. Response is the same as
-        from token create endpoint.
-      tags: [auth]
-      operationId: rhub.api.auth.token.refresh_token
-      parameters:
-        - in: header
-          name: Authorization
-          description: Bearer token is refresh token, not access token!
-          schema:
-            type: string
-            example: Bearer eyJhbGciOiJIUzI1...VLzc
-          required: true
-      responses:
-        200:
-          $ref: '#/components/responses/auth_token'
-        default:
-          $ref: '#/components/responses/problem'
+      $ref: 'auth.yml#/endpoints/token_refresh'
   /me:
     get:
-      summary: Get info about logged in user
-      tags: [auth]
-      operationId: rhub.api.auth.user.get_current_user
-      responses:
-        200:
-          $ref: '#/components/responses/user_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'auth.yml#/endpoints/me'
+
   /tower/server:
     get:
       summary: Get list of Tower servers

--- a/src/openapi/openapi.yml
+++ b/src/openapi/openapi.yml
@@ -7,131 +7,6 @@ servers:
   - url: /v0
 
 components:
-  schemas:
-    ID:
-      type: integer
-      minimum: 1
-    Policy:
-      type: object
-      properties:
-        id:
-          description: Internal ID
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          description: Name
-          type: string
-        department:
-          description: Department Name
-          type: string
-        constraint:
-          type: object
-          properties:
-            sched_avail:
-              type: array
-              items:
-                type: string
-                format: date-time
-              maxItems: 2
-            serv_avail:
-              type: number
-            consumption:
-              type: string
-            density:
-              type: string
-            attribute:
-              type: string
-            cost:
-              type: number
-            location:
-              type: string
-              maxLength: 4
-    BriefPolicy:
-      type: object
-      properties:
-        id:
-          description: Internal ID
-          allOf:
-            - $ref: '#/components/schemas/ID'
-            - readOnly: true
-        name:
-          description: Name
-          type: string
-        department:
-          description: Department Name
-          type: string
-
-  parameters:
-    policy_id:
-      name: id
-      in: path
-      description: ID of the Policy
-      required: true
-      schema:
-        $ref: '#/components/schemas/ID'
-
-  requestBodies:
-
-    policy_post:
-      description: Policy
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/Policy'
-              - required:
-                  - name
-                  - department
-          example:
-            name: Test User
-            department: Test Department
-            constraint:
-              location: RDU2
-    policy_patch:
-      description: Policy properties to update
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Policy'
-          example:
-            constraint:
-              location: RDU2
-    policy_search:
-      description: Policy search
-      required: true
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/Policy'
-          example:
-            constraint:
-              location: RDU2
-
-
-  responses:
-    problem: {$ref: 'common.yml#/responses/problem'}  # TODO remove
-
-    policies_list:
-      description: List of Policies
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/BriefPolicy'
-    policies_get:
-      description: Policy
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Policy'
-
   securitySchemes:
     basic:
       type: http
@@ -355,86 +230,19 @@ paths:
   /tower/webhook_notification:
     post:
       $ref: 'tower.yml#/endpoints/webhook_notification'
+
   /policies:
     get:
-      summary: Get policy list
-      tags: [policy]
-      operationId: rhub.api.policies.list_policies
-      responses:
-        200:
-          $ref: '#/components/responses/policies_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'policy.yml#/endpoints/policy_list'
     post:
-      summary: Create policy
-      tags: [policy]
-      operationId: rhub.api.policies.create_policy
-      requestBody:
-        $ref: '#/components/requestBodies/policy_post'
-      responses:
-        200:
-          $ref: '#/components/responses/policies_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
-  /policies/{id}:
+      $ref: 'policy.yml#/endpoints/policy_create'
+  /policies/{policy_id}:
     get:
-      summary: Get policy
-      tags: [policy]
-      operationId: rhub.api.policies.get_policy
-      parameters:
-        - $ref: '#/components/parameters/policy_id'
-      responses:
-        200:
-          $ref: '#/components/responses/policies_get'
-        404:
-          description: Not found
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'policy.yml#/endpoints/policy_get'
     patch:
-      summary: Update policy
-      tags: [policy]
-      operationId: rhub.api.policies.update_policy
-      parameters:
-        - $ref: '#/components/parameters/policy_id'
-      requestBody:
-        $ref: '#/components/requestBodies/policy_patch'
-      responses:
-        200:
-          $ref: '#/components/responses/policies_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'policy.yml#/endpoints/policy_update'
     delete:
-      summary: Delete policy
-      tags: [policy]
-      operationId: rhub.api.policies.delete_policy
-      parameters:
-        - $ref: '#/components/parameters/policy_id'
-      responses:
-        200:
-          $ref: '#/components/responses/policies_get'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'policy.yml#/endpoints/policy_delete'
   /policies/search:
     post:
-      summary: Search Policies
-      tags: [policy]
-      operationId: rhub.api.policies.search_policies
-      requestBody:
-        $ref: '#/components/requestBodies/policy_search'
-      responses:
-        200:
-          $ref: '#/components/responses/policies_list'
-        default:
-          $ref: '#/components/responses/problem'
-      security:
-        - oauth2: []
+      $ref: 'policy.yml#/endpoints/policy_search'

--- a/src/openapi/policy.yml
+++ b/src/openapi/policy.yml
@@ -1,0 +1,212 @@
+model:
+
+  Policy:
+    type: object
+    properties:
+      id:
+        description: Internal ID
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        description: Name
+        type: string
+      department:
+        description: Department Name
+        type: string
+      constraint:
+        type: object
+        properties:
+          sched_avail:
+            type: array
+            items:
+              type: string
+              format: date-time
+            maxItems: 2
+          serv_avail:
+            type: number
+          consumption:
+            type: string
+          density:
+            type: string
+          attribute:
+            type: string
+          cost:
+            type: number
+          location:
+            type: string
+            maxLength: 4
+
+  BriefPolicy:
+    type: object
+    properties:
+      id:
+        description: Internal ID
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        description: Name
+        type: string
+      department:
+        description: Department Name
+        type: string
+
+parameters:
+
+  policy_id:
+    name: policy_id
+    in: path
+    description: ID of the Policy
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+
+endpoints:
+
+  policy_list:
+    summary: Get policy list
+    tags: [policy]
+    operationId: rhub.api.policies.list_policies
+    responses:
+      '200':
+        description: List of Policies
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/BriefPolicy'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  policy_create:
+    summary: Create policy
+    tags: [policy]
+    operationId: rhub.api.policies.create_policy
+    requestBody:
+      description: Policy
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Policy'
+              - required:
+                  - name
+                  - department
+          example:
+            name: Test User
+            department: Test Department
+            constraint:
+              location: RDU2
+    responses:
+      '200':
+        description: Policy
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Policy'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  policy_get:
+    summary: Get policy
+    tags: [policy]
+    operationId: rhub.api.policies.get_policy
+    parameters:
+      - $ref: '#/parameters/policy_id'
+    responses:
+      '200':
+        description: Policy
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Policy'
+      '404':
+        description: Not found
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  policy_update:
+    summary: Update policy
+    tags: [policy]
+    operationId: rhub.api.policies.update_policy
+    parameters:
+      - $ref: '#/parameters/policy_id'
+    requestBody:
+      description: Policy properties to update
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Policy'
+          example:
+            constraint:
+              location: RDU2
+    responses:
+      '200':
+        description: Policy
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Policy'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  policy_delete:
+    summary: Delete policy
+    tags: [policy]
+    operationId: rhub.api.policies.delete_policy
+    parameters:
+      - $ref: '#/parameters/policy_id'
+    responses:
+      '200':
+        description: Policy
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Policy'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  policy_search:
+    summary: Search Policies
+    tags: [policy]
+    operationId: rhub.api.policies.search_policies
+    requestBody:
+      description: Policy search
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Policy'
+          example:
+            constraint:
+              location: RDU2
+    responses:
+      '200':
+        description: List of Policies
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/BriefPolicy'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []

--- a/src/openapi/tower.yml
+++ b/src/openapi/tower.yml
@@ -1,0 +1,563 @@
+model:
+
+  Server:
+    type: object
+    properties:
+      id:
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        type: string
+      description:
+        type: string
+      enabled:
+        type: boolean
+      url:
+        type: string
+        format: url
+      credentials:
+        type: string
+        description: Tower credentials path (Vault mount/path)
+  Template:
+    type: object
+    properties:
+      id:
+        description: Internal ID
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      name:
+        type: string
+      description:
+        type: string
+      server_id:
+        description: Reference to Tower server (Server.id)
+        $ref: 'common.yml#/model/ID'
+      tower_template_id:
+        description: ID of template in remote Tower
+        $ref: 'common.yml#/model/ID'
+      tower_template_is_workflow:
+        description: Is template workflow?
+        type: boolean
+  Job:
+    type: object
+    properties:
+      id:
+        description: Internal ID
+        allOf:
+          - $ref: 'common.yml#/model/ID'
+          - readOnly: true
+      template_id:
+        description: Reference to Tower template (Template.id)
+        $ref: 'common.yml#/model/ID'
+      tower_job_id:
+        description: ID of job in remote Tower
+        $ref: 'common.yml#/model/ID'
+      launched_by:
+        description: UUID of user who launched job
+        $ref: 'common.yml#/model/UUID'
+      status:
+        description: Job status
+        type: string
+      created_at:
+        type: string
+        format: date-time
+      started:
+        type: boolean
+      started_at:
+        type: string
+        format: date-time
+        x-nullable: true
+      finished:
+        type: boolean
+      finished_at:
+        type: string
+        format: date-time
+        x-nullable: true
+      failed:
+        type: boolean
+
+  WebhookNotification:
+    type: object
+    properties:
+      id:
+        description: jobId
+        type: integer
+      name:
+        description: jobName
+        type: string
+      url:
+        description: URL to Job on Tower
+        type: string
+      created_by:
+        $ref: 'common.yml#/model/UUID'
+      started:
+        description: Date/Time job started
+        type: string
+        format: date-time
+        x-nullable: true
+      finished:
+        description: Date/Time job finished
+        type: string
+        format: date-time
+        x-nullable: true
+      status:
+        description: Job status
+        type: string
+      traceback:
+        description: Traceback if failed
+        type: string
+        x-nullable: true
+      inventory:
+        description: Inventory used by Job
+        type: string
+        x-nullable: true
+      project:
+        description: Project job belongs to
+        type: string
+        x-nullable: true
+      playbook:
+        description: Playbook executed in Job
+        type: string
+        x-nullable: true
+      credential:
+        description: Credential used by Job
+        type: string
+        x-nullable: true
+      limit:
+        description: Job limit
+        type: string
+        x-nullable: true
+      extra_vars:
+        type: string
+        description: Extra variables for playbook encoded as a dictionary within a string
+        x-nullable: true
+      hosts:
+        type: object
+        additionalProperties:
+          type: object
+          properties:
+            localhost:
+              type: object
+              properties:
+                failed:
+                  type: boolean
+                changed:
+                  type: integer
+                dark:
+                  type: integer
+                failures:
+                  type: integer
+                ok:
+                  type: integer
+                processed:
+                  type: integer
+                skipped:
+                  type: integer
+                rescued:
+                  type: integer
+                ignored:
+                  type: integer
+        x-nullable: true
+      body:
+        type: string
+        description: Enumerates all the nodes in the workflow job with a description of the job associated with each
+        x-nullable: true
+
+parameters:
+
+  server_id:
+    name: server_id
+    in: path
+    description: ID of the Tower server
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+  template_id:
+    name: template_id
+    in: path
+    description: ID of the Tower template
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+  job_id:
+    name: job_id
+    in: path
+    description: ID of the Tower job
+    required: true
+    schema:
+      $ref: 'common.yml#/model/ID'
+
+endpoints:
+
+  server_list:
+    summary: Get list of Tower servers
+    operationId: rhub.api.tower.list_servers
+    tags: [tower]
+    responses:
+      '200':
+        description: List of Tower Server
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Server'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  server_create:
+    summary: Create Tower server
+    operationId: rhub.api.tower.create_server
+    tags: [tower]
+    requestBody:
+      description: Tower Server
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Server'
+              - required:
+                  - name
+                  - url
+                  - credentials
+          example:
+            name: default
+            url: https://tower.example.com
+            credentials: kv/tower/prod/rhub
+    responses:
+      '200':
+        description: Tower Server
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Server'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  server_get:
+    summary: Get Tower server
+    operationId: rhub.api.tower.get_server
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/server_id'
+    responses:
+      '200':
+        description: Tower Server
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Server'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  server_update:
+    summary: Change Tower server
+    operationId: rhub.api.tower.update_server
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/server_id'
+    requestBody:
+      description: Tower Server properties to update
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Server'
+          example:
+            description: Default Tower server
+    responses:
+      '200':
+        description: Tower Server
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Server'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  server_delete:
+    operationId: rhub.api.tower.delete_server
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/server_id'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  template_list:
+    summary: Get list of Tower templates
+    operationId: rhub.api.tower.list_templates
+    tags: [tower]
+    responses:
+      '200':
+        description: List of Tower Template
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Template'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  template_create:
+    summary: Create Tower template
+    operationId: rhub.api.tower.create_template
+    tags: [tower]
+    requestBody:
+      description: Tower Template
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            allOf:
+              - $ref: '#/model/Template'
+              - required:
+                  - name
+                  - server_id
+                  - tower_template_id
+          example:
+            name: Create OpenStack project
+            tower_id: 1
+            tower_template_id: 123
+    responses:
+      '200':
+        description: Tower Template
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Template'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  template_get:
+    summary: Get Tower template
+    operationId: rhub.api.tower.get_template
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/template_id'
+    responses:
+      '200':
+        description: Tower Template
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/model/Template'
+                - type: object
+                  properties:
+                    tower_survey:
+                      type: object
+                      description: Survey spec from Tower API
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  template_update:
+    summary: Change Tower template
+    operationId: rhub.api.tower.update_template
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/template_id'
+    requestBody:
+      description: Tower Template properties to update
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/Server'
+          example:
+            description: Template to create a new project in OpenStack
+    responses:
+      '200':
+        description: Tower Template
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Template'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  template_delete:
+    summary: Delete Tower template
+    operationId: rhub.api.tower.delete_template
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/template_id'
+    responses:
+      '200':
+        description: success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  template_launch:
+    summary: Launch Tower template
+    operationId: rhub.api.tower.launch_template
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/template_id'
+    requestBody:
+      description: Tower Template launch parameters
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              extra_vars:
+                type: object
+                description: Extra variable to pass to the template
+            required:
+              - extra_vars
+          example:
+            extra_vars:
+              project_name: example-project
+              project_owner: example-user
+    responses:
+      '200':
+        description: Tower Job
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Job'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  template_list_jobs:
+    summary: List Tower template jobs
+    operationId: rhub.api.tower.list_template_jobs
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/template_id'
+    responses:
+      '200':
+        description: List of Tower Jobs
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Job'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  job_list:
+    summary: List Tower jobs
+    operationId: rhub.api.tower.list_jobs
+    tags: [tower]
+    responses:
+      '200':
+        description: List of Tower Jobs
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/model/Job'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  job_get:
+    summary: Get Tower job
+    operationId: rhub.api.tower.get_job
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/job_id'
+    responses:
+      '200':
+        description: Tower Job
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Job'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  job_relaunch:
+    summary: Re-launch Tower job
+    operationId: rhub.api.tower.relaunch_job
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/job_id'
+    responses:
+      '200':
+        description: Tower Job
+        content:
+          application/json:
+            schema:
+              $ref: '#/model/Job'
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  job_stdout:
+    summary: Get stdout of Tower job
+    operationId: rhub.api.tower.get_job_stdout
+    tags: [tower]
+    parameters:
+      - $ref: '#/parameters/job_id'
+    responses:
+      '200':
+        description: Ansible output
+        content:
+          text/plain:
+            schema:
+              type: string
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - oauth2: []
+
+  webhook_notification:
+    summary: Incoming webhook notification from Tower
+    tags: [tower]
+    operationId: rhub.api.tower.webhook_notification
+    requestBody:
+      description: Webhook notification from Tower
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/model/WebhookNotification'
+    responses:
+      '200':
+        description: Success
+      default:
+        $ref: 'common.yml#/responses/problem'
+    security:
+      - tower_webhook_notification_auth: []

--- a/src/rhub/api/__init__.py
+++ b/src/rhub/api/__init__.py
@@ -5,6 +5,7 @@ import importlib
 
 import connexion
 import click
+import prance
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 from flask import g, current_app
@@ -79,11 +80,10 @@ def create_app():
     """Create Connexion/Flask application."""
     root = os.path.dirname(rhub.__path__[0])
 
-    connexion_app = connexion.App(
-        __name__,
-        specification_dir=os.path.join(root, 'openapi'),
-    )
-    connexion_app.add_api('openapi.yml')
+    connexion_app = connexion.App(__name__)
+
+    parser = prance.ResolvingParser(os.path.join(root, 'openapi', 'openapi.yml'))
+    connexion_app.add_api(parser.specification)
 
     flask_app = connexion_app.app
     # Enable CORS (Cross-Origin Resource Sharing)

--- a/src/rhub/api/auth/group.py
+++ b/src/rhub/api/auth/group.py
@@ -24,7 +24,7 @@ def list_groups():
 def create_group(body):
     try:
         group_id = get_keycloak().group_create(body)
-        logger.info(f'Created group {id}')
+        logger.info(f'Created group {group_id}')
         return get_keycloak().group_get(group_id), 200
     except KeycloakGetError as e:
         logger.exception(e)
@@ -34,9 +34,9 @@ def create_group(body):
         return problem(500, 'Unknown Error', str(e))
 
 
-def get_group(id):
+def get_group(group_id):
     try:
-        return get_keycloak().group_get(id), 200
+        return get_keycloak().group_get(group_id), 200
     except KeycloakGetError as e:
         logger.exception(e)
         return problem_from_keycloak_error(e)
@@ -45,11 +45,11 @@ def get_group(id):
         return problem(500, 'Unknown Error', str(e))
 
 
-def update_group(id, body):
+def update_group(group_id, body):
     try:
-        get_keycloak().group_update(id, body)
-        logger.info(f'Updated group {id}')
-        return get_keycloak().group_get(id), 200
+        get_keycloak().group_update(group_id, body)
+        logger.info(f'Updated group {group_id}')
+        return get_keycloak().group_get(group_id), 200
     except KeycloakGetError as e:
         logger.exception(e)
         return problem_from_keycloak_error(e)
@@ -58,10 +58,10 @@ def update_group(id, body):
         return problem(500, 'Unknown Error', str(e))
 
 
-def delete_group(id):
+def delete_group(group_id):
     try:
-        get_keycloak().group_delete(id)
-        logger.info(f'Deleted group {id}')
+        get_keycloak().group_delete(group_id)
+        logger.info(f'Deleted group {group_id}')
         return {}, 200
     except KeycloakGetError as e:
         logger.exception(e)
@@ -71,9 +71,9 @@ def delete_group(id):
         return problem(500, 'Unknown Error', str(e))
 
 
-def list_group_users(id):
+def list_group_users(group_id):
     try:
-        return get_keycloak().group_user_list(id), 200
+        return get_keycloak().group_user_list(group_id), 200
     except KeycloakGetError as e:
         logger.exception(e)
         return problem_from_keycloak_error(e)
@@ -82,13 +82,13 @@ def list_group_users(id):
         return problem(500, 'Unknown Error', str(e))
 
 
-def list_group_roles(id):
+def list_group_roles(group_id):
     raise NotImplementedError
 
 
-def add_group_role(id, body):
+def add_group_role(group_id, body):
     raise NotImplementedError
 
 
-def delete_group_role(id, body):
+def delete_group_role(group_id, body):
     raise NotImplementedError

--- a/src/rhub/api/auth/role.py
+++ b/src/rhub/api/auth/role.py
@@ -37,9 +37,9 @@ def create_role(body):
         return problem(500, 'Unknown Error', str(e))
 
 
-def get_role(id):
+def get_role(role_id):
     try:
-        return get_keycloak().role_get(id), 200
+        return get_keycloak().role_get(role_id), 200
     except KeycloakGetError as e:
         logger.exception(e)
         return problem_from_keycloak_error(e)
@@ -48,11 +48,11 @@ def get_role(id):
         return problem(500, 'Unknown Error', str(e))
 
 
-def update_role(id, body):
+def update_role(role_id, body):
     try:
-        get_keycloak().role_update(id, body)
+        get_keycloak().role_update(role_id, body)
         role_name = body['name']
-        logger.info(f'Updated role {id}')
+        logger.info(f'Updated role {role_id}')
         return get_keycloak().role_get(role_name), 200
     except KeycloakGetError as e:
         logger.exception(e)
@@ -62,10 +62,10 @@ def update_role(id, body):
         return problem(500, 'Unknown Error', str(e))
 
 
-def delete_role(id):
+def delete_role(role_id):
     try:
-        get_keycloak().role_delete(id)
-        logger.info(f'Deleted role {id}')
+        get_keycloak().role_delete(role_id)
+        logger.info(f'Deleted role {role_id}')
         return {}, 200
     except KeycloakGetError as e:
         logger.exception(e)

--- a/src/rhub/api/auth/user.py
+++ b/src/rhub/api/auth/user.py
@@ -35,9 +35,9 @@ def create_user(body):
         return problem(500, 'Unknown Error', str(e))
 
 
-def get_user(id):
+def get_user(user_id):
     try:
-        return get_keycloak().user_get(id), 200
+        return get_keycloak().user_get(user_id), 200
     except KeycloakGetError as e:
         logger.exception(e)
         return problem_from_keycloak_error(e)
@@ -46,11 +46,11 @@ def get_user(id):
         return problem(500, 'Unknown Error', str(e))
 
 
-def update_user(id, body):
+def update_user(user_id, body):
     try:
-        get_keycloak().user_update(id, body)
-        logger.info(f'Updated user {id}')
-        return get_keycloak().user_get(id), 200
+        get_keycloak().user_update(user_id, body)
+        logger.info(f'Updated user {user_id}')
+        return get_keycloak().user_get(user_id), 200
     except KeycloakGetError as e:
         logger.exception(e)
         return problem_from_keycloak_error(e)
@@ -59,10 +59,10 @@ def update_user(id, body):
         return problem(500, 'Unknown Error', str(e))
 
 
-def delete_user(id):
+def delete_user(user_id):
     try:
-        get_keycloak().user_delete(id)
-        logger.info(f'Deleted user {id}')
+        get_keycloak().user_delete(user_id)
+        logger.info(f'Deleted user {user_id}')
         return {}, 200
     except KeycloakGetError as e:
         logger.exception(e)
@@ -72,9 +72,9 @@ def delete_user(id):
         return problem(500, 'Unknown Error', str(e))
 
 
-def list_user_groups(id):
+def list_user_groups(user_id):
     try:
-        return get_keycloak().user_group_list(id), 200
+        return get_keycloak().user_group_list(user_id), 200
     except KeycloakGetError as e:
         logger.exception(e)
         return problem_from_keycloak_error(e)
@@ -83,9 +83,9 @@ def list_user_groups(id):
         return problem(500, 'Unknown Error', str(e))
 
 
-def add_user_group(id, body):
+def add_user_group(user_id, body):
     try:
-        get_keycloak().group_user_add(id, body['id'])
+        get_keycloak().group_user_add(user_id, body['id'])
         return {}, 200
     except KeycloakGetError as e:
         logger.exception(e)
@@ -95,9 +95,9 @@ def add_user_group(id, body):
         return problem(500, 'Unknown Error', str(e))
 
 
-def delete_user_group(id):
+def delete_user_group(user_id):
     try:
-        get_keycloak().group_user_remove(id, request.json['id'])
+        get_keycloak().group_user_remove(user_id, request.json['id'])
         return {}, 200
     except KeycloakGetError as e:
         logger.exception(e)
@@ -107,15 +107,15 @@ def delete_user_group(id):
         return problem(500, 'Unknown Error', str(e))
 
 
-def list_user_roles(id):
+def list_user_roles(user_id):
     raise NotImplementedError
 
 
-def add_user_role(id, body):
+def add_user_role(user_id, body):
     raise NotImplementedError
 
 
-def delete_user_role(id, body):
+def delete_user_role(user_id, body):
     raise NotImplementedError
 
 

--- a/src/rhub/api/lab/bundle.py
+++ b/src/rhub/api/lab/bundle.py
@@ -6,13 +6,13 @@ def create_bundle(body):
     raise NotImplementedError
 
 
-def get_bundle(id):
+def get_bundle(bundle_id):
     raise NotImplementedError
 
 
-def update_bundle(id, body):
+def update_bundle(bundle_id, body):
     raise NotImplementedError
 
 
-def delete_bundle(id):
+def delete_bundle(bundle_id):
     raise NotImplementedError

--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -6,13 +6,13 @@ def create_cluster(body):
     raise NotImplementedError
 
 
-def get_cluster(id):
+def get_cluster(cluster_id):
     raise NotImplementedError
 
 
-def update_cluster(id, body):
+def update_cluster(cluster_id, body):
     raise NotImplementedError
 
 
-def delete_cluster(id):
+def delete_cluster(cluster_id):
     raise NotImplementedError

--- a/src/rhub/api/lab/region.py
+++ b/src/rhub/api/lab/region.py
@@ -75,10 +75,10 @@ def create_region(body, user):
     return row2dict(region)
 
 
-def get_region(id, user):
-    region = model.Region.query.get(id)
+def get_region(region_id, user):
+    region = model.Region.query.get(region_id)
     if not region:
-        return problem(404, 'Not Found', f'Region {id} does not exist')
+        return problem(404, 'Not Found', f'Region {region_id} does not exist')
 
     if region.users_group is not None:
         if not get_keycloak().user_check_role(user, ADMIN_ROLE):
@@ -89,10 +89,10 @@ def get_region(id, user):
     return row2dict(region)
 
 
-def update_region(id, body, user):
-    region = model.Region.query.get(id)
+def update_region(region_id, body, user):
+    region = model.Region.query.get(region_id)
     if not region:
-        return problem(404, 'Not Found', f'Region {id} does not exist')
+        return problem(404, 'Not Found', f'Region {region_id} does not exist')
 
     if not get_keycloak().user_check_role(user, ADMIN_ROLE):
         if not get_keycloak().user_check_group(user, region.owner_group):
@@ -127,10 +127,10 @@ def update_region(id, body, user):
     return row2dict(region)
 
 
-def delete_region(id, user):
-    region = model.Region.query.get(id)
+def delete_region(region_id, user):
+    region = model.Region.query.get(region_id)
     if not region:
-        return problem(404, 'Not Found', f'Region {id} does not exist')
+        return problem(404, 'Not Found', f'Region {region_id} does not exist')
 
     if not get_keycloak().user_check_role(user, ADMIN_ROLE):
         if not get_keycloak().user_check_group(user, region.owner_group):
@@ -155,13 +155,13 @@ def delete_region(id, user):
     logger.info(f'Region {region.name} (id {region.id}) deleted by user {user}')
 
 
-def list_region_templates(id):
+def list_region_templates(region_id):
     raise NotImplementedError
 
 
-def add_region_template(id, body):
+def add_region_template(region_id, body):
     raise NotImplementedError
 
 
-def delete_region_template(id, body):
+def delete_region_template(region_id, body):
     raise NotImplementedError

--- a/src/rhub/api/lab/template.py
+++ b/src/rhub/api/lab/template.py
@@ -6,25 +6,25 @@ def create_template(body):
     raise NotImplementedError
 
 
-def get_template(id):
+def get_template(template_id):
     raise NotImplementedError
 
 
-def update_template(id, body):
+def update_template(template_id, body):
     raise NotImplementedError
 
 
-def delete_template(id):
+def delete_template(template_id):
     raise NotImplementedError
 
 
-def list_template_bundles(id):
+def list_template_bundles(template_id):
     raise NotImplementedError
 
 
-def add_template_bundle(id, body):
+def add_template_bundle(template_id, body):
     raise NotImplementedError
 
 
-def delete_template_bundle(id, body):
+def delete_template_bundle(template_id, body):
     raise NotImplementedError

--- a/src/rhub/api/lab/tower.py
+++ b/src/rhub/api/lab/tower.py
@@ -6,13 +6,13 @@ def create_tower(body):
     raise NotImplementedError
 
 
-def get_tower(id):
+def get_tower(tower_id):
     raise NotImplementedError
 
 
-def update_tower(id, body):
+def update_tower(tower_id, body):
     raise NotImplementedError
 
 
-def delete_tower(id):
+def delete_tower(tower_id):
     raise NotImplementedError

--- a/src/rhub/api/policies.py
+++ b/src/rhub/api/policies.py
@@ -70,7 +70,7 @@ def check_access(func):
         keycloak = get_keycloak()
         if 'policy_id' in kwargs:
             current_user = kwargs['user']
-            group_name = 'policy-' + str(kwargs['policy_id']) + '-owners'
+            group_name = f'policy-{kwargs["policy_id"]}-owners'
             group_list = keycloak.user_group_list(current_user)
             groups = {group['name']: group for group in group_list}
             if group_name in groups.keys():
@@ -105,7 +105,7 @@ def create_policy(user, body):
     policy = model.Policy(**body)
     db.session.add(policy)
     db.session.commit()
-    group_name = 'policy-' + str(row2dict(policy)['id']) + '-owners'
+    group_name = f'policy-{policy.id}-owners'
     group = keycloak.group_create({'name': group_name})
     keycloak.group_user_add(current_user['id'], group)
     keycloak.group_role_add('policy-owner', group)
@@ -163,7 +163,7 @@ def delete_policy(user, policy_id, **kwargs):
         return problem(404, 'Not Found', 'Record Does Not Exist')
     keycloak = get_keycloak()
     groups = {group['name']: group for group in keycloak.group_list()}
-    group_name = 'policy-' + str(policy_id) + '-owners'
+    group_name = f'policy-{policy_id}-owners'
     group_id = groups[group_name]['id']
     keycloak.group_delete(group_id)
     return denormalize(row2dict(policy))

--- a/tox.ini
+++ b/tox.ini
@@ -35,5 +35,4 @@ commands = yamllint src
 
 
 [testenv:openapi]
-deps = openapi-spec-validator
-commands = openapi-spec-validator src/openapi/openapi.yml
+commands = prance validate src/openapi/openapi.yml


### PR DESCRIPTION
* split OpenAPI spec file to multiple files by module
* rename generic `id` params to endpoint specific `tower_id`, `region_id`, etc.

