### PR TITLE
make tower nullable for clusterevent

### DIFF
--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -260,9 +260,13 @@ model:
             type: string
             enum: [tower_job]
           tower_id:
-            $ref: 'common.yml#/model/ID'
+            anyOf:
+              - $ref: 'common.yml#/model/ID'
+              - nullable: true
           tower_job_id:
-            $ref: 'common.yml#/model/ID'
+            anyOf:
+              - $ref: 'common.yml#/model/ID'
+              - nullable: true
           status:
             type: string
       - properties:

--- a/src/rhub/lab/model.py
+++ b/src/rhub/lab/model.py
@@ -339,9 +339,9 @@ class ClusterTowerJobEvent(ClusterEvent):
         'polymorphic_identity': ClusterEventType.TOWER_JOB,
     }
 
-    tower_id = db.Column(db.Integer, db.ForeignKey('lab_tower.id'), nullable=False)
+    tower_id = db.Column(db.Integer, db.ForeignKey('lab_tower.id'), nullable=True)
     #: ID of template in Tower.
-    tower_job_id = db.Column(db.Integer, nullable=False)
+    tower_job_id = db.Column(db.Integer, nullable=True)
     #: :type: :class:`ClusterStatus`
     status = db.Column(db.Enum(ClusterStatus))
     #: :type: :class:`Tower`


### PR DESCRIPTION
## Description:
**Short summary:**
Cluster event has a oneOf field in the yml file but tower_id is not nullable in Postgres (even if the change is not a tower event)
