### PR TITLE
fix: allow dashes in region names and locations

### DIFF
--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -386,13 +386,11 @@ endpoints:
           properties:
             name:
               type: string
-              pattern: '^[\w%]+$'
               description: >
                 Name of a region. Wildcard ``%`` can be used to match zero, one,
                 or multiple characters
             location:
               type: string
-              pattern: '^[\w%]+$'
               description: >
                 Location of a region. Wildcard ``%`` can be used to match zero,
                 one, or multiple characters


### PR DESCRIPTION
## Description:
Allow dashes in the region names and locations by removing pattern restrictions.