### PR TITLE
fix: remove readOnly restriction on status field in lab/cluster API spec

### DIFF
--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -211,7 +211,6 @@ model:
         nullable: true
       status:
         type: string
-        readOnly: true
         nullable: true
       hosts:
         type: array

--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -222,7 +222,7 @@ def update_cluster(cluster_id, body, user):
 
     cluster_data = body.copy()
 
-    for key in ['name', 'region_id', 'status']:
+    for key in ['name', 'region_id']:
         if key in cluster_data:
             return problem(400, 'Bad Request',
                            f'Cluster {key} field cannot be changed.')


### PR DESCRIPTION
## Description:
Remove readOnly restriction on the "status" field in the lab/cluster API specification as well as allow updating of the status field for lab/cluster in the API.
