### PR TITLE
fix: remove pattern restriction on template names

### DIFF
--- a/src/openapi/tower.yml
+++ b/src/openapi/tower.yml
@@ -349,7 +349,6 @@ endpoints:
           properties:
             name:
               type: string
-              pattern: '^[\w%]+$'
               description: >
                 Name of a template. Wildcard ``%`` can be used to match zero,
                 one, or multiple characters


### PR DESCRIPTION
## Description:
**Short summary:**
Remove the pattern restriction on template names.  Similar to region names, we often include dashes in template names which the restriction prevented.
