### PR TITLE
Add a longer timeout on Dockerize

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -12,6 +12,9 @@ KEYCLOAK_REALM=
 # .credentials.secret
 KEYCLOAK_SECRET=
 
+# Amount of time that Dockerize will wait for Keycloak to become up and running
+KEYCLOAK_TIMEOUT="30s"
+
 # Admin user credentials
 KEYCLOAK_ADMIN_USER=
 KEYCLOAK_ADMIN_PASS=

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -13,5 +13,5 @@ fi
 
 exec dockerize \
     -wait tcp://$DB_HOST:$DB_PORT \
-    -wait ${KEYCLOAK_SERVER}realms/$KEYCLOAK_REALM -timeout 30s \
+    -wait ${KEYCLOAK_SERVER}realms/$KEYCLOAK_REALM -timeout ${KEYCLOAK_TIMEOUT:30s} \
     gunicorn --bind 0.0.0.0:8081 --log-level ${LOG_LEVEL:-info} "$RHUB_APP"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -13,5 +13,5 @@ fi
 
 exec dockerize \
     -wait tcp://$DB_HOST:$DB_PORT \
-    -wait ${KEYCLOAK_SERVER}realms/$KEYCLOAK_REALM \
+    -wait ${KEYCLOAK_SERVER}realms/$KEYCLOAK_REALM -timeout 30s \
     gunicorn --bind 0.0.0.0:8081 --log-level ${LOG_LEVEL:-info} "$RHUB_APP"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -13,5 +13,5 @@ fi
 
 exec dockerize \
     -wait tcp://$DB_HOST:$DB_PORT \
-    -wait ${KEYCLOAK_SERVER}realms/$KEYCLOAK_REALM -timeout ${KEYCLOAK_TIMEOUT:30s} \
+    -wait ${KEYCLOAK_SERVER}realms/$KEYCLOAK_REALM -timeout ${KEYCLOAK_TIMEOUT:-"30s"} \
     gunicorn --bind 0.0.0.0:8081 --log-level ${LOG_LEVEL:-info} "$RHUB_APP"


### PR DESCRIPTION
## Description:
**Short summary:**
Keycloak sometimes can take up to 10 seconds to load, while the API waits for it.

If, after a given amount of tries, the API cannot connect to it, the API will break, not enabling the development using containers when Docker brings up the entire project from scratch.

This aims to give a reasonable timeout time so Keycloak can start up and making the API load properly.
