### PR TITLE
Fix Keycloak groups and roles update after initial setup...

### DIFF
--- a/src/rhub/api/_setup.py
+++ b/src/rhub/api/_setup.py
@@ -28,11 +28,13 @@ def setup():
 
     if ADMIN_GROUP not in groups:
         logger.info(f'Creating admin group "{ADMIN_GROUP}"')
-        groups[ADMIN_GROUP] = keycloak.group_create({'name': ADMIN_GROUP})
+        admin_group_id = keycloak.group_create({'name': ADMIN_GROUP})
+        groups[ADMIN_GROUP] = keycloak.group_get(admin_group_id)
 
     if ADMIN_ROLE not in roles:
         logger.info(f'Creating admin role "{ADMIN_ROLE}"')
-        roles[ADMIN_ROLE] = keycloak.role_create({'name': ADMIN_ROLE})
+        admin_role_name = keycloak.role_create({'name': ADMIN_ROLE})
+        roles[ADMIN_ROLE] = keycloak.role_get(admin_role_name)
 
     if not any(role['name'] == ADMIN_ROLE
                for role in keycloak.group_role_list(groups[ADMIN_GROUP]['id'])):


### PR DESCRIPTION
## Description:
**Short summary:**
Fix the setup problem for `groups` and `roles`, since group_create and role_create return id, instead of full objects...

Example of the difference of `groups` variable:
```
# 1st (initial setup)
#groups[ADMIN_ROLE] = bb238142-19d5-43e8-b004-d0020b26a1bb

# 2nd (already added)
#groups[ADMIN_ROLE] = {'id': 'bb238142-19d5-43e8-b004-d0020b26a1bb', 'name': 'rhub-admin', 'path': '/rhub-admin', 'subGroups': []}
```
