### PR TITLE
Add gh-actions to trigger build on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)) && github.ref == 'refs/heads/master' }}
 
       - run: docker push quay.io/resource-hub-dev/rhub-api
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)) && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
Github Actions will only trigger a new build with a `push` event, but we also are working with Pull Requests.

This PR will enable Pull Requests to trigger gh-actions, but only when the PR is closed and it has been merged with the `master` branch.