### PR TITLE
add keycloak var for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
 
   keycloak:
     image: quay.io/keycloak/keycloak:${RHUB_IMAGE_KEYCLOAK_VERSION:-15.0.2}
+    environment:
+      - KEYCLOAK_FRONTEND_URL=http://localhost:8080/auth
     env_file:
       - .env
     ports:


### PR DESCRIPTION
This variable allows the token to be consumed by the front-end to match the token on the backend. Without this, the token gotten from the front-end cannot be authenticated by rhub-api, even though they both come from keycloak