### PR TITLE
Cluster events on status and expiration change

### DIFF
--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -320,6 +320,10 @@ model:
         type: string
         format: uuid
         nullable: true
+      user_name:
+        type: string
+        nullable: true
+        readOnly: true
       cluster_id:
         allOf:
           - $ref: 'common.yml#/model/ID'
@@ -339,6 +343,20 @@ model:
               - nullable: true
           status:
             $ref: '#/model/ClusterStatus'
+      - properties:
+          type:
+            type: string
+            enum: [status_change]
+          old_value:
+            anyOf:
+              - $ref: '#/model/ClusterStatus'
+              - nullable: true
+            example: Queued
+          new_value:
+            anyOf:
+              - $ref: '#/model/ClusterStatus'
+              - nullable: true
+            example: Active
       - properties:
           type:
             type: string


### PR DESCRIPTION
Finishing cluster history feature.


### Checklist

- [x] Related tests were updated
- [x] Related documentation was updated
- [x] OpenAPI file was updated
- [x] Run `tox`, no tests failed
