### PR TITLE
fix: Update Region API properties to align with database

### DIFF
--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -78,6 +78,7 @@ model:
       owner_group_name:
         type: string
         nullable: true
+        readOnly: true
       users_group:
         type: string
         format: uuid
@@ -85,6 +86,7 @@ model:
       users_group_name:
         type: string
         nullable: true
+        readOnly: true
       tower_id:
         $ref: 'common.yml#/model/ID'
       openstack:
@@ -159,6 +161,7 @@ model:
         example:
           hostname: satellite.example.com
           credentials: kv/region/rdu2-a/satellite
+          insecure: false
       dns_server:
         type: object
         properties:


### PR DESCRIPTION
Changed the API spec to add the readOnly tag on the following Region properties:
 - users_group_name
 - owners_group_name
  
 Additionally, added the "insecure" property to the example under Satellite as this is a required field.

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [x] OpenAPI file was updated
- [x] Run `tox`, no tests failed
