### PR TITLE
Add `migrations` folder to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !bin/
+!migrations/
 !src/
 !requirements.txt
 !.env.defaults


### PR DESCRIPTION
When building our Docker image, all folders are not included in the build, except some specific directories and files.

```
*
!bin/
!src/
!requirements.txt
!.env.defaults
```

This patch aims to add the `migrations` folder to it, so we can run `flask db upgrade` and install all database migrations accordingly.

With this patch, the migrations folder will not be ignored as well:


```
*
!bin/
!migrations/
!src/
!requirements.txt
!.env.defaults
```

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated
- [ ] Run `tox`, no tests failed
