### PR TITLE
Fix `cron-validator` dependency to version `1.0.4`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 attrs
 coloredlogs
 connexion[swagger-ui]
-cron-validator
+cron-validator==1.0.3
 dpath
 flask-apscheduler
 flask-cors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 attrs
 coloredlogs
 connexion[swagger-ui]
-cron-validator==1.0.3
+cron-validator == 1.0.3
 dpath
 flask-apscheduler
 flask-cors


### PR DESCRIPTION
The library `cron-validator` has released a new version today and its latest version is breaking our build process.

**Error in our build process:** [https://github.com/resource-hub-dev/rhub-api/runs/5289155872?check_suite_focus=true](https://github.com/resource-hub-dev/rhub-api/runs/5289155872?check_suite_focus=true)

**Release history:** [https://pypi.org/project/cron-validator/#history](https://pypi.org/project/cron-validator/#history)

For now, let's stick with version `1.0.3` and we will upgrade as soon as possible to `1.0.4`.

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated
- [x] Run `tox`, no tests failed
