### PR TITLE
Add openapi-spec-validator as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ flask-sqlalchemy
 flask_injector
 gunicorn
 hvac
+openapi-spec-validator
 openstacksdk
 prance
 prometheus_flask_exporter == 0.18.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,20 @@
+alembic
 attrs
+click
 coloredlogs
 connexion[swagger-ui]
 cron-validator == 1.0.3
 dpath
+flask
+flask_injector
 flask-apscheduler
 flask-cors
 flask-dotenv
 flask-migrate
 flask-sqlalchemy
-flask_injector
 gunicorn
 hvac
+injector
 openapi-spec-validator
 openstacksdk
 prance
@@ -20,4 +24,6 @@ python-dateutil
 python-keycloak == 0.25.0
 pyyaml
 requests
+SQLAlchemy
 tenacity
+Werkzeug


### PR DESCRIPTION
<!--

Please add a short description of the change.

Before opening a PR follow the steps in CONTRIBUTING.md.

When applicable, link the PR to the appropriate issue

-->

### Fixes

- This fixed the repository tip that was broken on tox (see details below).
  - https://github.com/resource-hub-dev/rhub-api/actions/runs/1887017373
  - https://github.com/resource-hub-dev/rhub-api/actions/runs/1887017347

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated
- [x] Run `tox`, no tests failed

### Tox output
```
========================================================================================================== short test summary info ===========================================================================================================
FAILED tests/test_api/test_lab/test_region.py::test_to_dict - injector.CallError: Call to KeycloakClient.__init__() failed: KeycloakClient.__init__() missing 6 required positional arguments: 'server', 'resource', 'realm', 'secret', 'ad...
ERROR tests/test_api/test_auth.py::test_token_create - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_me - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_list_users - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_create_user - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_get_user - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_update_user - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_delete_user - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_list_user_groups - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_add_user_group - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_delete_user_group - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_list_groups - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_create_group - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_get_group - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_update_group - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_delete_group - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_list_group_users - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_list_roles - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_create_role - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_get_role - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_update_role - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_auth.py::test_delete_role - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_policy.py::test_list_policy - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_policy.py::test_get_policy - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_policy.py::test_create_policy - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_policy.py::test_delete_policy - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_policy.py::test_update_policy - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_list_servers - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_get_server - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_create_server - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_update_server - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_delete_server - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_list_templates - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_get_template[workflow=False] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_get_template[workflow=True] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_get_template_towererror - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_create_template - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_update_template - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_delete_template - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_template_launch[workflow=False] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_template_launch[workflow=True] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_template_launch_towererror - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_job_relaunch - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_list_jobs - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_get_job - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_get_job_towererror - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_webhook[template] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_tower.py::test_webhook[workflow template] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_list_clusters - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_get_cluster - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_shared - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_in_disabled_region - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_invalid_name[short] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_invalid_name[long] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_invalid_name[invalid-characters] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_invalid_name[localhost] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_invalid_name[all] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_exceeded_reservation - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_set_lifespan_forbidden - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_update_cluster - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_update_cluster_ro_field[name] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_update_cluster_ro_field[region] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_update_cluster_reservation - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_update_cluster_exceeded_reservation - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_update_cluster_set_lifespan_forbidden - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_delete_cluster - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_get_cluster_events - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_get_cluster_hosts - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_create_cluster_hosts - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_cluster.py::test_delete_cluster_hosts - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_product.py::test_list_products - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_product.py::test_get_product - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_product.py::test_create_product - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_product.py::test_update_product - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_product.py::test_delete_product - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_list_regions - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_get_region - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_create_region - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_create_region_credentials - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_create_region_with_quota - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_create_region_fail_keycloak_cleanup - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_update_region - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_update_region_credentials - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_update_region_quota[quota enable] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_update_region_quota[quota disable] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_update_region_nested_data[openstack] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_update_region_nested_data[satellite] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_update_region_nested_data[dns_server] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_update_region_nested_data[ALL] - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_delete_region - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_region_list_products - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_region_add_product - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_region_disable_product - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_lab/test_region.py::test_region_delete_product - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_scheduler/test_cron.py::test_list - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_scheduler/test_cron.py::test_create - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_scheduler/test_cron.py::test_create_duplicate_name - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_scheduler/test_cron.py::test_get - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_scheduler/test_cron.py::test_update - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_scheduler/test_cron.py::test_update_duplicate_name - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
ERROR tests/test_api/test_scheduler/test_cron.py::test_delete - RuntimeError: No validation backend available! Install one of "flex", "openapi-spec-validator" or "swagger-spec-validator".
======================================================================================================= 1 failed, 101 errors in 1.98s ========================================================================================================
ERROR: InvocationError for command /home/guolivei/git/rhub-api/.tox/py3/bin/pytest -vv tests (exited with code 1)
__________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________
ERROR:   py3: commands failed
```