### PR TITLE
Change how clusters are deleted

### DIFF
--- a/migrations/versions/820fdebe8007_cluster_unique_name_change.py
+++ b/migrations/versions/820fdebe8007_cluster_unique_name_change.py
@@ -1,0 +1,29 @@
+"""
+cluster unique name change
+
+Revision ID: 820fdebe8007
+Revises: 154ca1030fe2
+Create Date: 2022-03-14 12:15:09.862003
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '820fdebe8007'
+down_revision = '154ca1030fe2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('lab_cluster_name_key', 'lab_cluster', type_='unique')
+    op.create_index('ix_name', 'lab_cluster', ['name'], unique=True,
+                    postgresql_where=sa.text("status != 'DELETED'"))
+
+
+def downgrade():
+    op.drop_index('ix_name', table_name='lab_cluster',
+                  postgresql_where=sa.text("status != 'DELETED'"))
+    op.create_unique_constraint('lab_cluster_name_key', 'lab_cluster', ['name'])

--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -1149,6 +1149,12 @@ endpoints:
             shared:
               type: boolean
               description: Filter shared clusters
+            deleted:
+              type: boolean
+              description: |
+                List deleted clusters. By default deleted clusters are not
+                included in the listing. When this filter is set to `true` only
+                deleted clusters will be listed.
       - name: sort
         in: query
         description: Sort clusters by attribute.
@@ -1307,6 +1313,12 @@ endpoints:
 
   cluster_delete:
     summary: Delete cluster
+    description: |
+      Clusters are not deleted immediately after calling this endpoint. Instead,
+      Tower job will be launched (`Product.tower_template_name_delete`) and the
+      cluster is marked as deleted from the job by changing status to "Deleted".
+      If deletion fails status should be changed to "Deletion Failed" and
+      cluster won't be deleted.
     tags: [lab]
     operationId: rhub.api.lab.cluster.delete_cluster
     parameters:

--- a/src/rhub/api/_setup.py
+++ b/src/rhub/api/_setup.py
@@ -129,3 +129,13 @@ def setup():
             job_params=None,
         )
     )
+    create_cronjob(
+        scheduler_model.SchedulerCronJob(
+            name='Cleanup deleted clusters',
+            description='Cleanup clusters that were successfully destroyed.',
+            enabled=True,
+            time_expr='0 * * * *',  # hourly
+            job_name=scheduler_jobs.cleanup_deleted_clusters.name,
+            job_params=None,
+        )
+    )

--- a/src/rhub/api/_setup.py
+++ b/src/rhub/api/_setup.py
@@ -126,7 +126,9 @@ def setup():
             enabled=True,
             time_expr='0 1 * * *',  # daily, 1 AM
             job_name=scheduler_jobs.delete_expired_clusters.name,
-            job_params=None,
+            job_params={
+                'reservation_grace_period': 3,
+            },
         )
     )
     create_cronjob(

--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -361,7 +361,7 @@ def update_cluster(cluster_id, body, user):
 
     cluster_data = body.copy()
 
-    for key in ['name', 'region_id']:
+    for key in ['name', 'region_id', 'product_id', 'product_params']:
         if key in cluster_data:
             return problem(400, 'Bad Request',
                            f'Cluster {key} field cannot be changed.')

--- a/src/rhub/lab/utils.py
+++ b/src/rhub/lab/utils.py
@@ -1,0 +1,49 @@
+import logging
+
+from rhub.lab import model
+from rhub.api import db
+from rhub.api.utils import date_now
+
+
+logger = logging.getLogger(__name__)
+
+
+def delete_cluster(cluster, user=None):
+    try:
+        tower_client = cluster.region.tower.create_tower_client()
+        tower_template = tower_client.template_get(
+            template_name=cluster.product.tower_template_name_delete,
+        )
+
+        logger.info(
+            f'Launching Tower template {tower_template["name"]} '
+            f'(id={tower_template["id"]}), '
+            f'extra_vars={cluster.tower_launch_extra_vars!r}'
+        )
+        tower_client.template_launch(
+            tower_template['id'],
+            {'extra_vars': cluster.tower_launch_extra_vars},
+        )
+
+        tower_job = {'id': 0}
+
+        cluster_event = model.ClusterTowerJobEvent(
+            cluster_id=cluster.id,
+            user_id=user,
+            date=date_now(),
+            tower_id=cluster.region.tower_id,
+            tower_job_id=tower_job['id'],
+            status=model.ClusterStatus.DELETION_QUEUED,
+        )
+        db.session.add(cluster_event)
+
+        cluster.status = model.ClusterStatus.DELETION_QUEUED
+
+        db.session.commit()
+        logger.info(f'Cluster {cluster.name} (id {cluster.id}) queued for deletion '
+                    f'by user {user}')
+
+    except Exception as e:
+        db.session.rollback()
+        logger.exception(e)
+        raise

--- a/src/rhub/scheduler/jobs.py
+++ b/src/rhub/scheduler/jobs.py
@@ -1,9 +1,11 @@
 import logging
+import contextlib
 
 import rhub.tower.model
-import rhub.lab.model
 from rhub.api import db
 from rhub.api.utils import date_now
+from rhub.lab import model as lab_model
+from rhub.lab import utils as lab_utils
 
 
 logger = logging.getLogger(__name__)
@@ -89,15 +91,15 @@ def delete_expired_clusters(params):
     """
     now = date_now()
 
-    expired_clusters = rhub.lab.model.Cluster.query.filter(
+    expired_clusters = lab_model.Cluster.query.filter(
         db.or_(
             db.and_(
-                ~rhub.lab.model.Cluster.reservation_expiration.is_(None),
-                rhub.lab.model.Cluster.reservation_expiration <= now,
+                ~lab_model.Cluster.reservation_expiration.is_(None),
+                lab_model.Cluster.reservation_expiration <= now,
             ),
             db.and_(
-                ~rhub.lab.model.Cluster.lifespan_expiration.is_(None),
-                rhub.lab.model.Cluster.lifespan_expiration <= now,
+                ~lab_model.Cluster.lifespan_expiration.is_(None),
+                lab_model.Cluster.lifespan_expiration <= now,
             ),
         )
     )
@@ -109,24 +111,5 @@ def delete_expired_clusters(params):
             extra={'cluster': cluster.to_dict(), 'region': cluster.region.to_dict()},
         )
 
-        try:
-            tower_client = cluster.region.tower.create_tower_client()
-            tower_template = tower_client.template_get(
-                template_name=cluster.product.tower_template_name_delete,
-            )
-
-            logger.info(
-                f'Launching Tower template {tower_template["name"]} '
-                f'(id={tower_template["id"]}), '
-                f'extra_vars={cluster.tower_launch_extra_vars!r}'
-            )
-            tower_client.template_launch(
-                tower_template['id'],
-                {'extra_vars': cluster.tower_launch_extra_vars},
-            )
-
-            db.session.delete(cluster)
-            db.session.commit()
-
-        except Exception as e:
-            logger.exception(e)
+        with contextlib.suppress(Exception):
+            lab_utils.delete_cluster(cluster)

--- a/tests/test_api/test_lab/test_cluster.py
+++ b/tests/test_api/test_lab/test_cluster.py
@@ -78,7 +78,7 @@ def test_list_clusters(client, keycloak_mock, mocker):
     sample_region = _create_test_region()
     sample_product = _create_test_product()
     keycloak_mock.user_get.return_value = {'id': user_id, 'username': 'test-user'}
-    model.Cluster.query.limit.return_value.offset.return_value = [
+    model.Cluster.query.filter.return_value.limit.return_value.offset.return_value = [
         model.Cluster(
             id=1,
             name='testcluster',
@@ -98,7 +98,7 @@ def test_list_clusters(client, keycloak_mock, mocker):
     ]
     mocker.patch.object(model.Cluster, 'hosts', [])
     mocker.patch.object(model.Cluster, 'quota', None)
-    model.Cluster.query.count.return_value = 1
+    model.Cluster.query.filter.return_value.count.return_value = 1
 
     rv = client.get(
         f'{API_BASE}/lab/cluster',
@@ -860,7 +860,8 @@ def test_delete_cluster(client, db_session_mock, keycloak_mock, mocker):
         },
     })
 
-    db_session_mock.delete.assert_called_with(cluster)
+    # Clusters should not be deleted immediately
+    db_session_mock.delete.assert_not_called()
     db_session_mock.commit.assert_called()
 
 


### PR DESCRIPTION
Clusters were deleted from the DB immediately after a tower job was queued. If the deletion job failed, we had no info about that in the API. This MR changes how clusters are deleted. API/Backend only changes the status to 'Delete Queued' and deletion will be handled by the delete job that should update status to 'Deleted' if the deletion was successful. Deleted clusters are then cleaned up by the cron job.

### Checklist

- [x] Related tests were updated
- [x] Related documentation was updated
- [x] OpenAPI file was updated
- [x] Run `tox`, no tests failed
