### PR TITLE
Forbid deleting a cluster in creating state

### DIFF
--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -1531,6 +1531,9 @@ endpoints:
       cluster is marked as deleted from the job by changing status to "Deleted".
       If deletion fails status should be changed to "Deletion Failed" and
       cluster won't be deleted.
+
+      Clusters that are in a creating state cannot be deleted. Before deleting,
+      the cluster must be in the `Active` state or in any of failed states.
     tags: [lab]
     operationId: rhub.api.lab.cluster.delete_cluster
     parameters:

--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -478,6 +478,13 @@ def delete_cluster(cluster_id, user):
         return problem(400, 'Bad Request',
                        f'Cluster {cluster_id} was already deleted')
 
+    if cluster.status.is_creating:
+        return problem(
+            400, 'Bad Request',
+            f'Cluster {cluster_id} is in creating state. Before deleting, '
+            'the cluster must be in the Active state or in any of failed states.',
+        )
+
     try:
         lab_utils.delete_cluster(cluster, user)
     except Exception:


### PR DESCRIPTION
If create and delete playbooks (post and delete API requests) are
launched immediately after each other, resources in OpenStack will be
allocated for a cluster that no longer exists in the API because delete
is much faster. That leaves allocated resources in OS that cannot be
viewed/deleted via RHub.

<!--

Please add a short description of the change.

Before opening a PR follow the steps in CONTRIBUTING.md.

When applicable, link the PR to the appropriate issue

-->

### Fixes

- [EXDRHUB-757](https://issues.redhat.com/browse/EXDRHUB-757)

### Checklist

- [x] Related tests were updated
- [x] Related documentation was updated
- [x] OpenAPI file was updated
- [x] Run `tox`, no tests failed
