### PR TITLE
Improve cluster status fields

### DIFF
--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -253,6 +253,16 @@ model:
       - Provisioning Queued
       - Queued
 
+  ClusterStatusFlag:
+    type: string
+    nullable: true
+    enum:
+      - active
+      - creating
+      - deleted
+      - deleting
+      - failed
+
   Cluster:
     type: object
     properties:
@@ -304,6 +314,10 @@ model:
         nullable: true
       status:
         $ref: '#/model/ClusterStatus'
+      status_flag:
+        allOf:
+          - $ref: '#/model/ClusterStatusFlag'
+          - readOnly: true
       quota:
         anyOf:
           - $ref: '#/model/Quota'
@@ -1358,6 +1372,10 @@ endpoints:
               format: uuid
               nullable: true
               description: ID of the group or ``null``.
+            status:
+              $ref: '#/model/ClusterStatus'
+            status_flag:
+              $ref: '#/model/ClusterStatusFlag'
             shared:
               type: boolean
               description: Filter shared clusters

--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -164,6 +164,18 @@ def list_clusters(keycloak: KeycloakClient,
     if 'group_id' in filter_:
         clusters = clusters.filter(model.Cluster.group_id == filter_['group_id'])
 
+    if 'status' in filter_:
+        clusters = clusters.filter(
+            model.Cluster.status == model.ClusterStatus(filter_['status'])
+        )
+
+    if 'status_flag' in filter_:
+        clusters = clusters.filter(
+            model.Cluster.status.in_(
+                model.ClusterStatus.flag_statuses(filter_['status_flag'])
+            )
+        )
+
     if 'shared' in filter_:
         if sharedcluster_group_id := _get_sharedcluster_group_id():
             if filter_['shared']:

--- a/tests/test_api/test_lab/test_cluster.py
+++ b/tests/test_api/test_lab/test_cluster.py
@@ -125,6 +125,7 @@ def test_list_clusters(client, keycloak_mock, mocker):
                 'reservation_expiration': None,
                 'lifespan_expiration': None,
                 'status': model.ClusterStatus.ACTIVE.value,
+                'status_flag': model.ClusterStatus.ACTIVE.flag,
                 'region_name': 'test',
                 'user_name': 'test-user',
                 'group_name': None,
@@ -215,6 +216,7 @@ def test_get_cluster(client, keycloak_mock, mocker):
         'reservation_expiration': None,
         'lifespan_expiration': None,
         'status': model.ClusterStatus.ACTIVE.value,
+        'status_flag': model.ClusterStatus.ACTIVE.flag,
         'region_name': 'test',
         'user_name': 'test-user',
         'group_name': None,
@@ -332,7 +334,7 @@ def test_create_cluster(client, keycloak_mock, db_session_mock, mocker):
     assert cluster_event.tower_job_id == 321
 
     assert rv.json['user_id'] == '00000000-0000-0000-0000-000000000000'
-    assert rv.json['status'] == model.ClusterStatus.QUEUED
+    assert rv.json['status'] == model.ClusterStatus.QUEUED.value
     assert rv.json['created'] == '2021-01-01T01:00:00+00:00'
 
 


### PR DESCRIPTION
* add 'status_flag' field that is more general, for cases when user
  wants to check if cluster, for example, failed, but doesn't care in
  which phase exactly
* add filtering by 'status' and 'status_flag'

<!--

Please add a short description of the change.

Before opening a PR follow the steps in CONTRIBUTING.md.

When applicable, link the PR to the appropriate issue

-->

### Fixes

- [EXDRHUB-785](https://issues.redhat.com/browse/EXDRHUB-785)
- [EXDRHUB-787](https://issues.redhat.com/browse/EXDRHUB-787)

### Checklist

- [x] Related tests were updated
- [x] Related documentation was updated
- [x] OpenAPI file was updated
- [x] Run `tox`, no tests failed
