### PR TITLE
Fix cluster status update

### DIFF
--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -457,6 +457,8 @@ def update_cluster(cluster_id, body, user):
         db.session.add(cluster_event)
 
     if 'status' in cluster_data:
+        cluster_data['status'] = model.ClusterStatus(cluster_data['status'])
+
         cluster_event = model.ClusterStatusChangeEvent(
             cluster_id=cluster.id,
             user_id=user,


### PR DESCRIPTION
Status update somehow worked even without converting string to
ClusterStatus, but it doesn't work now. It seems that string value is no
longer auto-converted to ClusterStatus by SQLAlchemy, the error is:

```
sqlalchemy.exc.DataError: (psycopg2.errors.InvalidTextRepresentation)
invalid input value for enum clusterstatus: "Active"
LINE 1: UPDATE lab_cluster SET status='Active' WHERE lab_cluster.id ...
```
