### PR TITLE
bug: convert quota object to dictionary in create_cluster()

### DIFF
--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -329,7 +329,7 @@ def create_cluster(keycloak: KeycloakClient, body, user):
 
     if (product.flavors is not None):
         current_user_quota_usage = region.get_user_quota_usage(user)
-        user_quota = region.user_quota
+        user_quota = region.user_quota.to_dict()
         params = cluster.product_params
         node_params_keys = list(
             filter(lambda param: param.find('node') != -1, params.keys()))


### PR DESCRIPTION
<!--

Resolves a bug in create_cluster():

AttributeError: 'Quota' object has no attribute 'keys'.  Code was expecting quota to be a dictionary rather than an object; converted obj to dict to resolve.

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated
- [ ] Run `tox`, no tests failed
