### PR TITLE
Add cluster admin role

### DIFF
--- a/src/rhub/api/_setup.py
+++ b/src/rhub/api/_setup.py
@@ -7,7 +7,8 @@ from rhub.api import db, di
 from rhub.auth import ADMIN_USER, ADMIN_GROUP, ADMIN_ROLE
 from rhub.auth.keycloak import KeycloakClient
 from rhub.tower import model as tower_model  # noqa: F401
-from rhub.lab import SHAREDCLUSTER_USER, SHAREDCLUSTER_GROUP, SHAREDCLUSTER_ROLE
+from rhub.lab import (SHAREDCLUSTER_USER, SHAREDCLUSTER_GROUP, SHAREDCLUSTER_ROLE,
+                      CLUSTER_ADMIN_ROLE)
 from rhub.lab import model as lab_model  # noqa: F401
 from rhub.policies import model as policies_model  # noqa: F401
 from rhub.scheduler import model as scheduler_model  # noqa: F401
@@ -96,6 +97,17 @@ def setup_keycloak():
                     f'to sharedcluster group "{SHAREDCLUSTER_GROUP}"')
         keycloak.group_user_add(sharedcluster_user['id'],
                                 groups[SHAREDCLUSTER_GROUP]['id'])
+
+    if CLUSTER_ADMIN_ROLE not in roles:
+        logger.info(f'Creating role "{CLUSTER_ADMIN_ROLE}"')
+        role_name = keycloak.role_create({'name': CLUSTER_ADMIN_ROLE})
+        roles[CLUSTER_ADMIN_ROLE] = keycloak.role_get(role_name)
+
+    if not any(role['name'] == CLUSTER_ADMIN_ROLE
+               for role in keycloak.group_role_list(groups[SHAREDCLUSTER_GROUP]['id'])):
+        logger.info(f'Adding role "{CLUSTER_ADMIN_ROLE}" '
+                    f'to sharedcluster group "{SHAREDCLUSTER_GROUP}"')
+        keycloak.group_role_add(CLUSTER_ADMIN_ROLE, groups[SHAREDCLUSTER_GROUP]['id'])
 
 
 def create_cronjob(cronjob):

--- a/src/rhub/lab/__init__.py
+++ b/src/rhub/lab/__init__.py
@@ -6,3 +6,6 @@ SHAREDCLUSTER_GROUP = 'sharedclusters'
 
 SHAREDCLUSTER_ROLE = 'sharedclusters'
 """Role required to create a shared cluster."""
+
+CLUSTER_ADMIN_ROLE = 'cluster-admin'
+"""Role for cluster administrators, required to change cluster status."""


### PR DESCRIPTION
Unprivileged users should not be able to change status. For example,
changing status to "deleted" would be a problem because it would bypass
deleting resources.

Added cluster admin role that has permissions to perform any operation
on cluster, but nothing else (eg. create region).

<!--

Please add a short description of the change.

Before opening a PR follow the steps in CONTRIBUTING.md.

When applicable, link the PR to the appropriate issue

-->

### Fixes

- [EXDRHUB-915](https://issues.redhat.com/browse/EXDRHUB-915)

### Checklist

- [x] Related tests were updated
- [x] Related documentation was updated
- [x] OpenAPI file was updated
- [x] Run `tox`, no tests failed
