### PR TITLE
WIP: fix old_value and new_value output for ClusterEvent

### DIFF
--- a/src/rhub/lab/model.py
+++ b/src/rhub/lab/model.py
@@ -590,6 +590,12 @@ class ClusterStatusChangeEvent(ClusterEvent):
     old_value = db.Column('status_old', db.Enum(ClusterStatus))
     new_value = db.Column('status_new', db.Enum(ClusterStatus))
 
+    def to_dict(self):
+        data = super().to_dict()
+        data["new_value"] = self.new_value.value
+        data["old_value"] = self.old_value.value
+        return data
+
 
 class ClusterReservationChangeEvent(ClusterEvent):
     __mapper_args__ = {


### PR DESCRIPTION
Bug: return value in get_cluster_event and list_cluster_events have invalid string values: 

```
    "new_value": "[Active]",
    "old_value": "[Active]",
```

This is because `new_value` and `old_value` are of type enum. When `event.to_dict()` was called, the wrong format was applied