### PR TITLE
Refactor condition

### DIFF
--- a/src/openapi/lab.yml
+++ b/src/openapi/lab.yml
@@ -501,8 +501,15 @@ model:
               default: false
             condition:
               description: Condition for extra validations that need values from other options.
+              type: object
+              properties:
+                msg:
+                  type: string
+                data:
+                  type: array
+              example: {msg: "Extra_nic must be true and num_nodes must be great than 1",
+                        data: ["and", ["param_eq", "extra_nic", true], ["param_gt", "num_nodes", 1]]}
               nullable: true
-              example: ["and", ["param_eq", "extra_nic", true], ["param_gt", "num_nodes", 1]]
             display_condition:
               description: Condition when to display option based on the values of other options.
               nullable: true

--- a/src/rhub/lab/model.py
+++ b/src/rhub/lab/model.py
@@ -720,7 +720,7 @@ class Product(db.Model, ModelMixin):
                     invalid_params[var] = 'value not allowed'
 
             if (c := param_spec.get('condition')) is not None:
-                if not condition_eval(c, cluster_params):
+                if not condition_eval(c.data, cluster_params):
                     invalid_params[var] = 'value does not satisfy the condition'
 
         if invalid_params:


### PR DESCRIPTION
Refactor condition to this format
### Example
```
{
 msg: "error message",
 data: ['param_eq', 'foo', 'bar'],
}
```

This way, the UI and CLI do not have to render error messages and can output specific error message when condition fails

### Fixes

- [EXDRHUB-931](https://issues.redhat.com/browse/EXDRHUB-931)

### Checklist

- [X] OpenAPI file was updated
- [X] Run `tox`, no tests failed
