### PR TITLE
OTEL container for testing/developing mode.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,6 @@ include src/rhub/bare_metal/model/ironic_template_data.json
 include src/rhub/bare_metal/tasks/playbooks/*.yml
 
 recursive-include migrations *.py
+recursive-include config *yaml
 recursive-include src/rhub/openapi *.yml
 recursive-include src/rhub/api/monitor *.yml

--- a/config/otel.yaml
+++ b/config/otel.yaml
@@ -1,0 +1,60 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+  # in this case we have a prometheus-like (hence the 'prometheus' section)
+  # exporter which will be located at this address.
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "internal-rhub-exporter"
+          scrape_interval: 15s
+          static_configs:
+            - targets: ["prometheus-exporter:9100"]
+
+exporters:
+  # in this case we have a prometheus-like endpoint so other readers
+  # can grab its metrics via federation.
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+  # logging exporter will be turned on when we have a fluent-bit proxy
+  # in the middle.
+  logging:
+
+processors:
+  # the regular batch processor, which doesn't really change any of the data.
+  batch:
+
+extensions:
+  # basic extensions to assess health.
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  # here we tie all services, input (receivers), processors and output (exporters)
+  # using the forementioned endpoints.
+
+  # notice how we have already something that forwards metrics but nothing really
+  # defined on traces.
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]
+
+    metrics:
+      receivers: [otlp, prometheus]
+      processors: [batch]
+      exporters: [logging, prometheus]
+
+  # metrics from itself.
+  telemetry:
+    metrics:
+      level: detailed
+      address: 0.0.0.0:8888

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,17 @@ services:
       retries: 5
       timeout: 30s
 
+  otel:
+    image: otel/opentelemetry-collector-contrib-dev:latest
+    ports:
+      - "8889:8889" # prometheus federation
+      - "8888:8888" # metrics from otel itself
+      - "1888:1888" # pprof extension
+      - "55679:55679" # zpages extension
+    volumes:
+      - ./config/otel.yaml:/etc/otel/config.yaml:ro
+    healthcheck:
+      disable: true
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Adding OTEL container basic config to allow scraping from the internal Prometheus exporter.

The idea is to have a baseline to inject generated configuration and start integrating the rest of monitoring into this project.

### Checklist

- [ ] Related tests were updated (not applicable so far, configuration generation will require tests)
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated (not applicable)
- [ ] Run `tox`, no tests failed (not applicable)
