### PR TITLE
Fix small issue on location schema

### DIFF
--- a/src/rhub/openapi/lab.yml
+++ b/src/rhub/openapi/lab.yml
@@ -54,10 +54,10 @@ model:
           - $ref: 'common.yml#/model/ID'
           - nullable: true
       location:
+        readOnly: true
         anyOf:
           - $ref: '#/model/Location'
           - nullable: true
-            readOnly: true
       description:
         type: string
       banner:

--- a/src/rhub/openapi/policy.yml
+++ b/src/rhub/openapi/policy.yml
@@ -47,10 +47,10 @@ model:
               - $ref: 'common.yml#/model/ID'
               - nullable: true
           location:
+            readOnly: true
             anyOf:
               - $ref: 'lab.yml#/model/Location'
               - nullable: true
-                readOnly: true
 
   BriefPolicy:
     type: object


### PR DESCRIPTION
The 'readOnly' property needs to be present if the 'location' object is present.

### Fixes

- [EXDRHUB-1035](https://issues.redhat.com/browse/EXDRHUB-1035)

### Checklist

- [x] Related tests were updated
- [x] Related documentation was updated
- [x] OpenAPI file was updated
- [x] Run `tox`, no tests failed
