### PR TITLE
Update dependencies inside docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+GIT_ROOT := $(shell git rev-parse --show-toplevel)
+
 default:
 
 init:
@@ -34,4 +36,13 @@ clean:
 	$(MAKE) -C docs clean
 
 requirements.txt: setup.py
-	pip-compile setup.py
+	rm -f requirements.txt
+	docker run \
+	--rm \
+	--pull always \
+	-e USER \
+	-u "$(id -u):$(id -g)" \
+	-v "$(GIT_ROOT):/tmp/app" \
+	-w /tmp/app \
+	registry.access.redhat.com/ubi8/python-39 \
+	/bin/bash -c 'pip install pip-tools && pip-compile'


### PR DESCRIPTION
Some dependencies are generated differently with Python 3.9 (the Docker's image version) and 3.10 (default on Fedora 36).
To avoid these kind of mistakes (that I've done), it's safer to update the `requirements.txt` file inside a container.

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated
- [x] Run `tox`, no tests failed
