### PR TITLE
fix reboot error due to code changes

### DIFF
--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -770,8 +770,7 @@ def reboot_hosts(cluster_id, body, user):
     rebooted_hosts = []
 
     try:
-        os_project_name = cluster.region.get_user_project_name(cluster.owner_id)
-        os_client = cluster.region.create_openstack_client(os_project_name)
+        os_client = cluster.project.create_openstack_client()
         for server in os_client.compute.servers():
             if server.hostname in hosts_to_reboot:
                 logger.info(


### PR DESCRIPTION
Reboot is returning 500 because:

- create_openstack_client is refactored to openstack
- get_user_project_name no longer exists


### Fixes

- EXDRHUB-1386

### Checklist

- [X] Related tests were updated
- [X] Related documentation was updated
- [X] OpenAPI file was updated
- [X] Run `tox`, no tests failed
