### PR TITLE
Set broker to support websocket 

### DIFF
--- a/config/rabbitmq/enabled_plugins
+++ b/config/rabbitmq/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management, rabbitmq_web_stomp, rabbitmq_stomp].

--- a/config/rabbitmq/rabbitmq.conf
+++ b/config/rabbitmq/rabbitmq.conf
@@ -1,0 +1,3 @@
+#more https://www.rabbitmq.com/configure.html#config-file
+
+web_stomp.tcp.port = 15674

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,11 +106,16 @@ services:
       - .env
     ports:
       - '5672:5672'
+      - '15674:15674' #webstomp
     healthcheck:
       test: [ "CMD", "rabbitmq-diagnostics", "-q", "ping" ]
       interval: 30s
       retries: 5
       timeout: 30s
+    volumes:
+      - ./config/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ./config/rabbitmq/enabled_plugins:/etc/rabbitmq/enabled_plugins:ro
+
 
   otel:
     image: otel/opentelemetry-collector-contrib-dev:latest

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ ignore =
     sonar-project.properties
     tests/**
     tox.ini
-
+    config/rabbitmq/*
 
 [testenv:bandit]
 usedevelop = False


### PR DESCRIPTION

Configuration to make broker container accessible via web-sockets.


### Fixes

- [EXDRHUB-1232](https://issues.redhat.com/browse/EXDRHUB-1232) 

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated
- [ ] Run `tox`, no tests failed
