### PR TITLE
Exdrhub1804

### DIFF
--- a/src/rhub/lab/model.py
+++ b/src/rhub/lab/model.py
@@ -377,12 +377,12 @@ class Cluster(db.Model, ModelMixin):
     @property
     def authorized_keys(self):
         keys = set(self.owner.ssh_keys)
-        if self.group:
-            for user in self.group.users:
-                keys |= set(user.ssh_keys)
-        elif self.shared:
+        if self.shared:
             users_query = user_model.User.query.filter(user_model.User.deleted.isnot(True))
             for user in users_query:
+                keys |= set(user.ssh_keys)
+        elif self.group:
+            for user in self.group.users:
                 keys |= set(user.ssh_keys)
         return list(keys)
 


### PR DESCRIPTION
Modify API to allow shared clusters to bypass product parameter and quota validations since they often exceed those values.  Additionally, fix the order of conditions for sshkey authorization to first check for shared cluster before checking other groups.

### Fixes

- #<number>

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated
- [ ] Run `tox`, no tests failed
