### PR TITLE
Add hostname to Splunk fields

### DIFF
--- a/src/rhub/splunk_hec.py
+++ b/src/rhub/splunk_hec.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import urllib.request
+import socket
 
 
 def _json_serializer(value):
@@ -20,7 +21,7 @@ class SplunkHecHandler(logging.Handler):
     }
 
     def __init__(self, base_url, token, source=None, sourcetype=None, index=None,
-                 fields=None):
+                 fields=None, host=None):
         super().__init__()
 
         self.base_url = base_url.rstrip('/')
@@ -29,6 +30,7 @@ class SplunkHecHandler(logging.Handler):
         self.sourcetype = sourcetype
         self.index = index
         self.fields = fields or []
+        self.host = host or socket.gethostname()
 
         self.request(f'{self.endpoint_url}/health')
 
@@ -60,6 +62,7 @@ class SplunkHecHandler(logging.Handler):
             'event': data,
             'fields': fields,
             'time': record.created,
+            'host': self.host,
         }
 
         if self.source:


### PR DESCRIPTION
Needed to determine from which container logs are (flask api, celery worker, celery cron).

<!--

Please add a short description of the change.

Before opening a PR follow the steps in CONTRIBUTING.md.

When applicable, link the PR to the appropriate issue

-->

### Fixes

- #<number>

### Checklist


- [ ] Run `tox`, no tests failed
