### PR TITLE
Prepend 'rhb_' rather than 'ql_' to project name

### DIFF
--- a/src/rhub/api/lab/cluster.py
+++ b/src/rhub/api/lab/cluster.py
@@ -341,7 +341,7 @@ def create_cluster(body, user):
 
     else:
         user_row = auth_model.User.query.get(user)
-        project_name = f'ql_{user_row.name}'
+        project_name = f'rhb_{user_row.name}'
 
         project_query = openstack_model.Project.query.filter(
             db.and_(


### PR DESCRIPTION
As we move towards GA, the naming standard for OSP projects we create for RHub is changing to 'rhb_' rather than 'ql_'.

### Fixes

- [EXDRHUB-1922](https://issues.redhat.com/browse/EXDRHUB-1922)

### Checklist

- [ ] Related tests were updated
- [ ] Related documentation was updated
- [ ] OpenAPI file was updated
- [x] Run `tox`, no tests failed
